### PR TITLE
Add CI and replace the boilerplate READMEs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: CI
+
+on:
+  push:
+    branches: [main, master]
+  pull_request: {}
+
+jobs:
+  backend:
+    name: Backend
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.25"
+          cache-dependency-path: backend/go.sum
+      - run: go build ./...
+      - run: go vet ./...
+      - run: go test ./...
+
+  frontend:
+    name: Frontend
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: pnpm
+          cache-dependency-path: frontend/pnpm-lock.yaml
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm build
+      - run: pnpm exec vitest run
+      # lint is intentionally not a gate yet: the tree has ~219 lint errors
+      # (mostly no-var). Add `pnpm lint` here after the lint cleanup.

--- a/README.md
+++ b/README.md
@@ -1,78 +1,57 @@
-# Stanza Bonanza 
+# Stanza Bonanza
 
-Unlike other poetry sites, Stanza Bonanza encourages open collaboration between poets. Users can create a new poem, write a stanza or two, and then wait for other users to extend that poem, adding their own personal spin and enriching the piece in the process. Before long, a diverse tapestry comes to life! 
+Unlike other poetry sites, Stanza Bonanza encourages open collaboration between poets. Users can create a new poem, write a stanza or two, and then wait for other users to extend that poem, adding their own personal spin and enriching the piece in the process. Before long, a diverse tapestry comes to life!
 
-Poems on Stanza Bonanza are more than the sum of their parts! 
+Poems on Stanza Bonanza are more than the sum of their parts!
 
 If poets desire more control over their work, they can specify certain constraints.
 
-___
+---
 
-This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
+## Stack
 
-## Available Scripts
+- **Backend**: Go 1.25, chi router, Postgres (raw SQL migrations), WebAuthn passkeys
+  and magic-link auth. In `backend/`.
+- **Frontend**: React + Vite + TypeScript, React Query, Zustand, Tailwind,
+  react-markdown. In `frontend/` (pnpm).
 
-In the project directory, you can run:
+## Develop
 
-### `yarn start`
+```bash
+make dev        # Postgres (docker-compose) + backend + frontend
+make migrate    # apply DB migrations (needs DATABASE_URL)
+make test       # backend + frontend tests
+make lint
+```
 
-Runs the app in the development mode.<br />
-Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
+Or per side: `make dev-backend`, `make dev-frontend`. Frontend on `:5173`, backend on `:8080`.
 
-The page will reload if you make edits.<br />
-You will also see any lint errors in the console.
+## Environment
 
-### `yarn test`
+Backend config lives in `backend/internal/config/config.go`, set via env or a `.env`:
 
-Launches the test runner in the interactive watch mode.<br />
-See the section about [running tests](https://facebook.github.io/create-react-app/docs/running-tests) for more information.
+| Var | Required | Default |
+|---|---|---|
+| `DATABASE_URL` | yes | — |
+| `SESSION_SECRET` | yes | — |
+| `PORT` | no | `8080` |
+| `ALLOWED_ORIGINS` | no | `http://localhost:5173` |
+| `WEBAUTHN_RP_ID` / `WEBAUTHN_RP_NAME` / `WEBAUTHN_RP_ORIGINS` | no | localhost defaults |
+| `RESEND_API_KEY` | for magic-link email | — |
+| `MAGIC_LINK_BASE_URL` | no | `http://localhost:5173/auth/verify` |
 
-### `yarn build`
+## Deploy
 
-Builds the app for production to the `build` folder.<br />
-It correctly bundles React in production mode and optimizes the build for the best performance.
+The backend deploys to Fly.io from `backend/fly.toml` (`fly deploy`); the frontend
+builds to static assets (`pnpm build`).
 
-The build is minified and the filenames include the hashes.<br />
-Your app is ready to be deployed!
+## Layout
 
-See the section about [deployment](https://facebook.github.io/create-react-app/docs/deployment) for more information.
-
-### `yarn eject`
-
-**Note: this is a one-way operation. Once you `eject`, you can’t go back!**
-
-If you aren’t satisfied with the build tool and configuration choices, you can `eject` at any time. This command will remove the single build dependency from your project.
-
-Instead, it will copy all the configuration files and the transitive dependencies (webpack, Babel, ESLint, etc) right into your project so you have full control over them. All of the commands except `eject` will still work, but they will point to the copied scripts so you can tweak them. At this point you’re on your own.
-
-You don’t have to ever use `eject`. The curated feature set is suitable for small and middle deployments, and you shouldn’t feel obligated to use this feature. However we understand that this tool wouldn’t be useful if you couldn’t customize it when you are ready for it.
-
-## Learn More
-
-You can learn more in the [Create React App documentation](https://facebook.github.io/create-react-app/docs/getting-started).
-
-To learn React, check out the [React documentation](https://reactjs.org/).
-
-### Code Splitting
-
-This section has moved here: https://facebook.github.io/create-react-app/docs/code-splitting
-
-### Analyzing the Bundle Size
-
-This section has moved here: https://facebook.github.io/create-react-app/docs/analyzing-the-bundle-size
-
-### Making a Progressive Web App
-
-This section has moved here: https://facebook.github.io/create-react-app/docs/making-a-progressive-web-app
-
-### Advanced Configuration
-
-This section has moved here: https://facebook.github.io/create-react-app/docs/advanced-configuration
-
-### Deployment
-
-This section has moved here: https://facebook.github.io/create-react-app/docs/deployment
-
-### `yarn build` fails to minify
-
-This section has moved here: https://facebook.github.io/create-react-app/docs/troubleshooting#npm-run-build-fails-to-minify
+```
+backend/
+  cmd/server      entrypoint
+  internal/       handler, service, repository, middleware, domain, config
+  migrations/     SQL migrations
+frontend/
+  src/            components, pages, hooks, store
+```

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,73 +1,17 @@
-# React + TypeScript + Vite
+# Stanza Bonanza — frontend
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+React + Vite + TypeScript client for [Stanza Bonanza](../README.md). React Query,
+Zustand, Tailwind, react-markdown; WebAuthn passkeys via `@simplewebauthn/browser`.
 
-Currently, two official plugins are available:
+## Commands
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Oxc](https://oxc.rs)
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/)
-
-## React Compiler
-
-The React Compiler is not enabled on this template because of its impact on dev & build performances. To add it, see [this documentation](https://react.dev/learn/react-compiler/installation).
-
-## Expanding the ESLint configuration
-
-If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:
-
-```js
-export default defineConfig([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-
-      // Remove tseslint.configs.recommended and replace with this
-      tseslint.configs.recommendedTypeChecked,
-      // Alternatively, use this for stricter rules
-      tseslint.configs.strictTypeChecked,
-      // Optionally, add this for stylistic rules
-      tseslint.configs.stylisticTypeChecked,
-
-      // Other configs...
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
+```bash
+pnpm install
+pnpm dev        # dev server on :5173
+pnpm build      # type-check + production build
+pnpm lint
+pnpm test       # vitest (watch); `pnpm exec vitest run` for a single run
 ```
 
-You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
-
-```js
-// eslint.config.js
-import reactX from 'eslint-plugin-react-x'
-import reactDom from 'eslint-plugin-react-dom'
-
-export default defineConfig([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-      // Enable lint rules for React
-      reactX.configs['recommended-typescript'],
-      // Enable lint rules for React DOM
-      reactDom.configs.recommended,
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
-```
+The dev server proxies the API to the Go backend on `:8080`. See the root
+[README](../README.md) for the full stack and env setup.


### PR DESCRIPTION
Fixes #60. Addresses #61 (lint deferred, see below).

Replaces the boilerplate READMEs with real docs. The root one kept the poem intro but dropped the Create React App section (yarn start, port 3000, eject); the frontend one was the untouched Vite template. Both now cover the actual Go + Vite/pnpm stack, dev commands, env vars, and deploy.

Adds a CI workflow: backend build + vet + test, and frontend install + build + tests. All green locally (backend 2 test packages pass, frontend 55 tests pass, both build). This also gives the Renovate auto-merge a real green-CI gate to rely on.

Left `pnpm lint` out of CI for now because the tree has ~219 lint errors (mostly no-var, auto-fixable). I'll do that cleanup separately and add lint to CI then.
