### PR TITLE
Backend security: rate limiter, email leak, magic-link validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
           version: 11.5.2
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           cache: pnpm
           cache-dependency-path: frontend/pnpm-lock.yaml
       - run: pnpm install --frozen-lockfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
+        with:
+          version: 11.5.2
       - uses: actions/setup-node@v4
         with:
           node-version: "20"

--- a/backend/internal/domain/user.go
+++ b/backend/internal/domain/user.go
@@ -9,7 +9,9 @@ import (
 type User struct {
 	ID          uuid.UUID `json:"id"`
 	DisplayName string    `json:"displayName"`
-	Email       string    `json:"email"`
+	// Email is the login id; never serialize it on the shared User (it embeds
+	// into poems, followers, public profiles). /me returns it via meResponse.
+	Email       string    `json:"-"`
 	Bio         string    `json:"bio"`
 	AvatarURL   string    `json:"avatarUrl"`
 	IsVerified  bool      `json:"isVerified"`

--- a/backend/internal/handler/auth.go
+++ b/backend/internal/handler/auth.go
@@ -221,7 +221,14 @@ func (h *AuthHandler) Me(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	respondJSON(w, http.StatusOK, user)
+	// Only the owner sees their own email.
+	respondJSON(w, http.StatusOK, meResponse{User: user, Email: user.Email})
+}
+
+// meResponse re-adds email (json:"-" on User) for the authenticated owner only.
+type meResponse struct {
+	*domain.User
+	Email string `json:"email"`
 }
 
 func (h *AuthHandler) GetProfile(w http.ResponseWriter, r *http.Request) {

--- a/backend/internal/middleware/ratelimit.go
+++ b/backend/internal/middleware/ratelimit.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"net"
 	"net/http"
 	"sync"
 
@@ -36,16 +37,23 @@ func (rl *RateLimiter) getLimiter(ip string) *rate.Limiter {
 
 func (rl *RateLimiter) Middleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ip := r.RemoteAddr
-		if forwarded := r.Header.Get("X-Forwarded-For"); forwarded != "" {
-			ip = forwarded
-		}
-
-		limiter := rl.getLimiter(ip)
+		limiter := rl.getLimiter(clientIP(r))
 		if !limiter.Allow() {
 			http.Error(w, `{"error":"rate limit exceeded"}`, http.StatusTooManyRequests)
 			return
 		}
 		next.ServeHTTP(w, r)
 	})
+}
+
+// clientIP keys the limiter on Fly's trusted client IP. Fly's edge overrides
+// Fly-Client-IP, so a client can't spoof it; raw X-Forwarded-For it can.
+func clientIP(r *http.Request) string {
+	if fly := r.Header.Get("Fly-Client-IP"); fly != "" {
+		return fly
+	}
+	if host, _, err := net.SplitHostPort(r.RemoteAddr); err == nil {
+		return host
+	}
+	return r.RemoteAddr
 }

--- a/backend/internal/service/auth.go
+++ b/backend/internal/service/auth.go
@@ -8,6 +8,8 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/mail"
+	"strings"
 	"sync"
 	"time"
 
@@ -107,22 +109,24 @@ func (s *AuthService) ValidateSession(ctx context.Context, token string) (uuid.U
 	return session.UserID, nil
 }
 
-func (s *AuthService) RequestMagicLink(ctx context.Context, email string) (string, error) {
-	_, err := s.users.GetByEmail(ctx, email)
+// normalizeEmail validates format and lowercases so case variants don't
+// become separate accounts.
+func normalizeEmail(email string) (string, error) {
+	addr, err := mail.ParseAddress(strings.TrimSpace(email))
 	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			var user = &domain.User{
-				Email:       email,
-				DisplayName: email,
-			}
-			if err := s.users.Create(ctx, user); err != nil {
-				return "", fmt.Errorf("creating user: %w", err)
-			}
-		} else {
-			return "", fmt.Errorf("looking up user: %w", err)
-		}
+		return "", fmt.Errorf("invalid email address")
+	}
+	return strings.ToLower(addr.Address), nil
+}
+
+func (s *AuthService) RequestMagicLink(ctx context.Context, email string) (string, error) {
+	email, err := normalizeEmail(email)
+	if err != nil {
+		return "", err
 	}
 
+	// Don't create the user here; unauthenticated requests shouldn't mint rows
+	// for arbitrary addresses. The user is created on successful verify.
 	rawToken, err := generateToken(32)
 	if err != nil {
 		return "", fmt.Errorf("generating token: %w", err)
@@ -161,7 +165,14 @@ func (s *AuthService) VerifyMagicLink(ctx context.Context, token string) (string
 
 	user, err := s.users.GetByEmail(ctx, link.Email)
 	if err != nil {
-		return "", nil, fmt.Errorf("finding user: %w", err)
+		if errors.Is(err, pgx.ErrNoRows) {
+			user = &domain.User{Email: link.Email, DisplayName: link.Email}
+			if err := s.users.Create(ctx, user); err != nil {
+				return "", nil, fmt.Errorf("creating user: %w", err)
+			}
+		} else {
+			return "", nil, fmt.Errorf("finding user: %w", err)
+		}
 	}
 
 	sessionToken, err := s.CreateSession(ctx, user.ID)

--- a/backend/internal/service/auth_test.go
+++ b/backend/internal/service/auth_test.go
@@ -100,36 +100,45 @@ func newAuthSvc(users *mockUserStore, sessions *mockSessionStore, links *mockMag
 
 // RequestMagicLink tests
 
-func TestAuthService_RequestMagicLink_NewUser(t *testing.T) {
+func TestAuthService_RequestMagicLink_DoesNotCreateUser(t *testing.T) {
 	users := &mockUserStore{}
 	sessions := &mockSessionStore{}
 	links := &mockMagicLinkStore{}
 	svc := newAuthSvc(users, sessions, links)
 
-	users.On("GetByEmail", mock.Anything, "new@test.com").Return(nil, pgx.ErrNoRows)
-	users.On("Create", mock.Anything, mock.AnythingOfType("*domain.User")).Return(nil)
+	// Request only stores a link now; the user is created on verify.
 	links.On("Create", mock.Anything, mock.AnythingOfType("*domain.MagicLink")).Return(nil)
 
 	token, err := svc.RequestMagicLink(context.Background(), "new@test.com")
 	require.NoError(t, err)
 	assert.NotEmpty(t, token)
-	users.AssertCalled(t, "Create", mock.Anything, mock.AnythingOfType("*domain.User"))
+	users.AssertNotCalled(t, "Create", mock.Anything, mock.Anything)
 }
 
-func TestAuthService_RequestMagicLink_ExistingUser(t *testing.T) {
+func TestAuthService_RequestMagicLink_RejectsInvalidEmail(t *testing.T) {
 	users := &mockUserStore{}
 	sessions := &mockSessionStore{}
 	links := &mockMagicLinkStore{}
 	svc := newAuthSvc(users, sessions, links)
 
-	existing := &domain.User{ID: uuid.New(), Email: "old@test.com"}
-	users.On("GetByEmail", mock.Anything, "old@test.com").Return(existing, nil)
-	links.On("Create", mock.Anything, mock.AnythingOfType("*domain.MagicLink")).Return(nil)
+	_, err := svc.RequestMagicLink(context.Background(), "not-an-email")
+	require.Error(t, err)
+	links.AssertNotCalled(t, "Create", mock.Anything, mock.Anything)
+}
 
-	token, err := svc.RequestMagicLink(context.Background(), "old@test.com")
+func TestAuthService_RequestMagicLink_NormalizesEmail(t *testing.T) {
+	users := &mockUserStore{}
+	sessions := &mockSessionStore{}
+	links := &mockMagicLinkStore{}
+	svc := newAuthSvc(users, sessions, links)
+
+	var stored *domain.MagicLink
+	links.On("Create", mock.Anything, mock.AnythingOfType("*domain.MagicLink")).
+		Run(func(args mock.Arguments) { stored = args.Get(1).(*domain.MagicLink) }).Return(nil)
+
+	_, err := svc.RequestMagicLink(context.Background(), "  Mixed@Case.COM ")
 	require.NoError(t, err)
-	assert.NotEmpty(t, token)
-	users.AssertNotCalled(t, "Create", mock.Anything, mock.Anything)
+	assert.Equal(t, "mixed@case.com", stored.Email)
 }
 
 // VerifyMagicLink tests
@@ -162,6 +171,35 @@ func TestAuthService_VerifyMagicLink_Success(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotEmpty(t, sessionToken)
 	assert.Equal(t, userID, returnedUser.ID)
+}
+
+func TestAuthService_VerifyMagicLink_CreatesUserIfMissing(t *testing.T) {
+	users := &mockUserStore{}
+	sessions := &mockSessionStore{}
+	links := &mockMagicLinkStore{}
+	svc := newAuthSvc(users, sessions, links)
+
+	rawToken, _ := generateToken(32)
+	hash := hashToken(rawToken)
+	linkID := uuid.New()
+
+	link := &domain.MagicLink{
+		ID:        linkID,
+		Email:     "fresh@test.com",
+		TokenHash: hash,
+		ExpiresAt: time.Now().Add(15 * time.Minute),
+	}
+
+	links.On("GetByTokenHash", mock.Anything, hash).Return(link, nil)
+	links.On("MarkUsed", mock.Anything, linkID).Return(nil)
+	users.On("GetByEmail", mock.Anything, "fresh@test.com").Return(nil, pgx.ErrNoRows)
+	users.On("Create", mock.Anything, mock.AnythingOfType("*domain.User")).Return(nil)
+	sessions.On("Create", mock.Anything, mock.AnythingOfType("*domain.Session")).Return(nil)
+
+	sessionToken, _, err := svc.VerifyMagicLink(context.Background(), rawToken)
+	require.NoError(t, err)
+	assert.NotEmpty(t, sessionToken)
+	users.AssertCalled(t, "Create", mock.Anything, mock.AnythingOfType("*domain.User"))
 }
 
 func TestAuthService_VerifyMagicLink_AlreadyUsed(t *testing.T) {

--- a/frontend/src/types/user.ts
+++ b/frontend/src/types/user.ts
@@ -1,7 +1,7 @@
 export interface User {
   id: string;
   displayName: string;
-  email: string;
+  email?: string; // only present on /auth/me (the owner), not public profiles
   bio: string;
   avatarUrl: string;
   isVerified: boolean;


### PR DESCRIPTION
Three backend security fixes, all verified green locally (go build/vet/test, frontend build).

- **#55** rate limiter keyed on Fly-Client-IP instead of raw X-Forwarded-For, so it can no longer be bypassed with a spoofed header.
- **#54** email dropped to `json:"-"` on the shared User; `/auth/me` still returns it for the owner via a dedicated struct. Frontend `email` made optional.
- **#59** magic-link request validates + normalises the email and no longer mints a user row; the user is created on successful verify. Updated the two request tests to the new behaviour and added verify-creates-user + normalisation tests.

Fixes #54, #55, #59.