### PR TITLE
Correctness: stanza review authz and transactional counters

### DIFF
--- a/backend/internal/repository/comment.go
+++ b/backend/internal/repository/comment.go
@@ -25,13 +25,26 @@ func (r *CommentRepository) Create(ctx context.Context, comment *domain.Comment)
 	comment.CreatedAt = now
 	comment.UpdatedAt = now
 
-	_, err := r.pool.Exec(ctx,
+	tx, err := r.pool.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback(ctx)
+
+	if _, err := tx.Exec(ctx,
 		`INSERT INTO comments (id, poem_id, author_id, parent_id, text, created_at, updated_at)
 		 VALUES ($1, $2, $3, $4, $5, $6, $7)`,
 		comment.ID, comment.PoemID, comment.AuthorID, comment.ParentID,
 		comment.Text, comment.CreatedAt, comment.UpdatedAt,
-	)
-	return err
+	); err != nil {
+		return err
+	}
+	if _, err := tx.Exec(ctx,
+		`UPDATE poems SET comment_count = comment_count + 1 WHERE id = $1`, comment.PoemID,
+	); err != nil {
+		return err
+	}
+	return tx.Commit(ctx)
 }
 
 func (r *CommentRepository) ListByPoem(ctx context.Context, poemID uuid.UUID, page domain.PaginationParams) ([]domain.Comment, int, error) {
@@ -76,7 +89,12 @@ func (r *CommentRepository) ListByPoem(ctx context.Context, poemID uuid.UUID, pa
 }
 
 func (r *CommentRepository) Delete(ctx context.Context, id uuid.UUID) error {
-	_, err := r.pool.Exec(ctx, `DELETE FROM comments WHERE id = $1`, id)
+	// Delete and decrement in one statement so the count can't drift.
+	_, err := r.pool.Exec(ctx,
+		`WITH deleted AS (DELETE FROM comments WHERE id = $1 RETURNING poem_id)
+		 UPDATE poems SET comment_count = comment_count - 1
+		 WHERE id = (SELECT poem_id FROM deleted)`, id,
+	)
 	return err
 }
 

--- a/backend/internal/repository/like.go
+++ b/backend/internal/repository/like.go
@@ -31,6 +31,42 @@ func (r *LikeRepository) Delete(ctx context.Context, userID, poemID uuid.UUID) e
 	return err
 }
 
+// ToggleLike flips the like and adjusts poems.like_count in one transaction so
+// concurrent requests can't drift the count. Returns the resulting liked state.
+func (r *LikeRepository) ToggleLike(ctx context.Context, userID, poemID uuid.UUID) (bool, error) {
+	tx, err := r.pool.Begin(ctx)
+	if err != nil {
+		return false, err
+	}
+	defer tx.Rollback(ctx)
+
+	del, err := tx.Exec(ctx, `DELETE FROM likes WHERE user_id = $1 AND poem_id = $2`, userID, poemID)
+	if err != nil {
+		return false, err
+	}
+	if del.RowsAffected() > 0 {
+		if _, err := tx.Exec(ctx, `UPDATE poems SET like_count = like_count - 1 WHERE id = $1`, poemID); err != nil {
+			return false, err
+		}
+		return false, tx.Commit(ctx)
+	}
+
+	ins, err := tx.Exec(ctx,
+		`INSERT INTO likes (user_id, poem_id, created_at) VALUES ($1, $2, now())
+		 ON CONFLICT (user_id, poem_id) DO NOTHING`,
+		userID, poemID,
+	)
+	if err != nil {
+		return false, err
+	}
+	if ins.RowsAffected() > 0 {
+		if _, err := tx.Exec(ctx, `UPDATE poems SET like_count = like_count + 1 WHERE id = $1`, poemID); err != nil {
+			return false, err
+		}
+	}
+	return true, tx.Commit(ctx)
+}
+
 func (r *LikeRepository) Exists(ctx context.Context, userID, poemID uuid.UUID) (bool, error) {
 	var exists bool
 	err := r.pool.QueryRow(ctx,

--- a/backend/internal/service/poem.go
+++ b/backend/internal/service/poem.go
@@ -193,12 +193,31 @@ func (s *PoemService) ReviewStanza(ctx context.Context, userID, poemID, stanzaID
 		return fmt.Errorf("not the poem author")
 	}
 
+	// The stanza must belong to this poem and still be pending, else an author
+	// could review a foreign stanza and re-approving would double-count.
+	stanzas, err := s.stanzas.ListByPoem(ctx, poemID)
+	if err != nil {
+		return fmt.Errorf("loading stanzas: %w", err)
+	}
+	var target *domain.Stanza
+	for i := range stanzas {
+		if stanzas[i].ID == stanzaID {
+			target = &stanzas[i]
+			break
+		}
+	}
+	if target == nil {
+		return fmt.Errorf("stanza does not belong to this poem")
+	}
+	if target.Status != domain.StanzaPending {
+		return fmt.Errorf("stanza is not pending review")
+	}
+
 	var status domain.StanzaStatus
 	var notifType domain.NotificationType
 	if approved {
 		status = domain.StanzaApproved
 		notifType = domain.NotifStanzaApproved
-		_ = s.poems.IncrementCounter(ctx, poemID, "stanza_count", 1)
 	} else {
 		status = domain.StanzaRejected
 		notifType = domain.NotifStanzaRejected
@@ -207,20 +226,17 @@ func (s *PoemService) ReviewStanza(ctx context.Context, userID, poemID, stanzaID
 	if err := s.stanzas.UpdateStatus(ctx, stanzaID, status); err != nil {
 		return fmt.Errorf("updating stanza status: %w", err)
 	}
+	if approved {
+		_ = s.poems.IncrementCounter(ctx, poemID, "stanza_count", 1)
+	}
 
-	stanzas, err := s.stanzas.ListByPoem(ctx, poemID)
-	if err == nil {
-		for _, st := range stanzas {
-			if st.ID == stanzaID && st.AuthorID != userID {
-				_ = s.notifs.Create(ctx, &domain.Notification{
-					RecipientID: st.AuthorID,
-					ActorID:     &userID,
-					Type:        notifType,
-					PoemID:      &poemID,
-				})
-				break
-			}
-		}
+	if target.AuthorID != userID {
+		_ = s.notifs.Create(ctx, &domain.Notification{
+			RecipientID: target.AuthorID,
+			ActorID:     &userID,
+			Type:        notifType,
+			PoemID:      &poemID,
+		})
 	}
 
 	return nil

--- a/backend/internal/service/poem_test.go
+++ b/backend/internal/service/poem_test.go
@@ -264,7 +264,7 @@ func TestPoemService_ReviewStanza_Approve_SendsNotification(t *testing.T) {
 	stanzaID := uuid.New()
 
 	poem := &domain.Poem{ID: poemID, AuthorID: authorID}
-	stanzaList := []domain.Stanza{{ID: stanzaID, AuthorID: submitterID}}
+	stanzaList := []domain.Stanza{{ID: stanzaID, PoemID: poemID, AuthorID: submitterID, Status: domain.StanzaPending}}
 
 	poems.On("GetByID", mock.Anything, poemID).Return(poem, nil)
 	stanzas.On("UpdateStatus", mock.Anything, stanzaID, domain.StanzaApproved).Return(nil)
@@ -289,7 +289,7 @@ func TestPoemService_ReviewStanza_Reject_SendsNotification(t *testing.T) {
 	stanzaID := uuid.New()
 
 	poem := &domain.Poem{ID: poemID, AuthorID: authorID}
-	stanzaList := []domain.Stanza{{ID: stanzaID, AuthorID: submitterID}}
+	stanzaList := []domain.Stanza{{ID: stanzaID, PoemID: poemID, AuthorID: submitterID, Status: domain.StanzaPending}}
 
 	poems.On("GetByID", mock.Anything, poemID).Return(poem, nil)
 	stanzas.On("UpdateStatus", mock.Anything, stanzaID, domain.StanzaRejected).Return(nil)
@@ -299,6 +299,47 @@ func TestPoemService_ReviewStanza_Reject_SendsNotification(t *testing.T) {
 	err := svc.ReviewStanza(context.Background(), authorID, poemID, stanzaID, false)
 	require.NoError(t, err)
 	notifs.AssertNumberOfCalls(t, "Create", 1)
+}
+
+func TestPoemService_ReviewStanza_ForeignStanza_Error(t *testing.T) {
+	poems := &mockPoemStore{}
+	stanzas := &mockStanzaStore{}
+	svc := newPoemSvc(poems, stanzas, &mockPoemNotifStore{})
+
+	authorID := uuid.New()
+	poemID := uuid.New()
+	stanzaID := uuid.New()
+
+	poem := &domain.Poem{ID: poemID, AuthorID: authorID}
+	// stanzaID is not in this poem's list.
+	poems.On("GetByID", mock.Anything, poemID).Return(poem, nil)
+	stanzas.On("ListByPoem", mock.Anything, poemID).Return([]domain.Stanza{{ID: uuid.New()}}, nil)
+
+	err := svc.ReviewStanza(context.Background(), authorID, poemID, stanzaID, true)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not belong")
+	stanzas.AssertNotCalled(t, "UpdateStatus", mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestPoemService_ReviewStanza_AlreadyReviewed_Error(t *testing.T) {
+	poems := &mockPoemStore{}
+	stanzas := &mockStanzaStore{}
+	svc := newPoemSvc(poems, stanzas, &mockPoemNotifStore{})
+
+	authorID := uuid.New()
+	poemID := uuid.New()
+	stanzaID := uuid.New()
+
+	poem := &domain.Poem{ID: poemID, AuthorID: authorID}
+	// already approved, so re-approving must not double-count.
+	stanzaList := []domain.Stanza{{ID: stanzaID, PoemID: poemID, Status: domain.StanzaApproved}}
+	poems.On("GetByID", mock.Anything, poemID).Return(poem, nil)
+	stanzas.On("ListByPoem", mock.Anything, poemID).Return(stanzaList, nil)
+
+	err := svc.ReviewStanza(context.Background(), authorID, poemID, stanzaID, true)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not pending")
+	poems.AssertNotCalled(t, "IncrementCounter", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 }
 
 func TestPoemService_ReviewStanza_NotAuthor_Error(t *testing.T) {

--- a/backend/internal/service/social.go
+++ b/backend/internal/service/social.go
@@ -10,8 +10,7 @@ import (
 )
 
 type likeStore interface {
-	Create(ctx context.Context, like *domain.Like) error
-	Delete(ctx context.Context, userID, poemID uuid.UUID) error
+	ToggleLike(ctx context.Context, userID, poemID uuid.UUID) (bool, error)
 	Exists(ctx context.Context, userID, poemID uuid.UUID) (bool, error)
 }
 
@@ -66,27 +65,13 @@ func NewSocialService(
 }
 
 func (s *SocialService) ToggleLike(ctx context.Context, userID, poemID uuid.UUID) (bool, error) {
-	exists, err := s.likes.Exists(ctx, userID, poemID)
+	liked, err := s.likes.ToggleLike(ctx, userID, poemID)
 	if err != nil {
-		return false, fmt.Errorf("checking like: %w", err)
+		return false, fmt.Errorf("toggling like: %w", err)
 	}
-
-	if exists {
-		if err := s.likes.Delete(ctx, userID, poemID); err != nil {
-			return false, fmt.Errorf("removing like: %w", err)
-		}
-		_ = s.poems.IncrementCounter(ctx, poemID, "like_count", -1)
+	if !liked {
 		return false, nil
 	}
-
-	var like = &domain.Like{
-		UserID: userID,
-		PoemID: poemID,
-	}
-	if err := s.likes.Create(ctx, like); err != nil {
-		return false, fmt.Errorf("adding like: %w", err)
-	}
-	_ = s.poems.IncrementCounter(ctx, poemID, "like_count", 1)
 
 	poem, err := s.poems.GetByID(ctx, poemID)
 	if err == nil && poem.AuthorID != userID {
@@ -112,8 +97,6 @@ func (s *SocialService) AddComment(ctx context.Context, userID, poemID uuid.UUID
 	if err := s.comments.Create(ctx, comment); err != nil {
 		return nil, fmt.Errorf("creating comment: %w", err)
 	}
-
-	_ = s.poems.IncrementCounter(ctx, poemID, "comment_count", 1)
 
 	poem, err := s.poems.GetByID(ctx, poemID)
 	if err == nil && poem.AuthorID != userID {
@@ -141,7 +124,6 @@ func (s *SocialService) DeleteComment(ctx context.Context, userID, commentID uui
 		return fmt.Errorf("deleting comment: %w", err)
 	}
 
-	_ = s.poems.IncrementCounter(ctx, comment.PoemID, "comment_count", -1)
 	return nil
 }
 

--- a/backend/internal/service/social_test.go
+++ b/backend/internal/service/social_test.go
@@ -16,11 +16,9 @@ import (
 
 type mockLikeStore struct{ mock.Mock }
 
-func (m *mockLikeStore) Create(ctx context.Context, like *domain.Like) error {
-	return m.Called(ctx, like).Error(0)
-}
-func (m *mockLikeStore) Delete(ctx context.Context, userID, poemID uuid.UUID) error {
-	return m.Called(ctx, userID, poemID).Error(0)
+func (m *mockLikeStore) ToggleLike(ctx context.Context, userID, poemID uuid.UUID) (bool, error) {
+	args := m.Called(ctx, userID, poemID)
+	return args.Bool(0), args.Error(1)
 }
 func (m *mockLikeStore) Exists(ctx context.Context, userID, poemID uuid.UUID) (bool, error) {
 	args := m.Called(ctx, userID, poemID)
@@ -125,9 +123,7 @@ func TestSocialService_ToggleLike_Like(t *testing.T) {
 	poemID := uuid.New()
 	poem := &domain.Poem{ID: poemID, AuthorID: authorID}
 
-	likes.On("Exists", mock.Anything, userID, poemID).Return(false, nil)
-	likes.On("Create", mock.Anything, mock.AnythingOfType("*domain.Like")).Return(nil)
-	poems.On("IncrementCounter", mock.Anything, poemID, "like_count", 1).Return(nil)
+	likes.On("ToggleLike", mock.Anything, userID, poemID).Return(true, nil)
 	poems.On("GetByID", mock.Anything, poemID).Return(poem, nil)
 	notifs.On("Create", mock.Anything, mock.AnythingOfType("*domain.Notification")).Return(nil)
 
@@ -145,9 +141,7 @@ func TestSocialService_ToggleLike_Unlike(t *testing.T) {
 	userID := uuid.New()
 	poemID := uuid.New()
 
-	likes.On("Exists", mock.Anything, userID, poemID).Return(true, nil)
-	likes.On("Delete", mock.Anything, userID, poemID).Return(nil)
-	poems.On("IncrementCounter", mock.Anything, poemID, "like_count", -1).Return(nil)
+	likes.On("ToggleLike", mock.Anything, userID, poemID).Return(false, nil)
 
 	liked, err := svc.ToggleLike(context.Background(), userID, poemID)
 	require.NoError(t, err)
@@ -168,7 +162,6 @@ func TestSocialService_AddComment_Success(t *testing.T) {
 	poem := &domain.Poem{ID: poemID, AuthorID: authorID}
 
 	comments.On("Create", mock.Anything, mock.AnythingOfType("*domain.Comment")).Return(nil)
-	poems.On("IncrementCounter", mock.Anything, poemID, "comment_count", 1).Return(nil)
 	poems.On("GetByID", mock.Anything, poemID).Return(poem, nil)
 	notifs.On("Create", mock.Anything, mock.AnythingOfType("*domain.Notification")).Return(nil)
 
@@ -190,7 +183,6 @@ func TestSocialService_AddComment_WithParent(t *testing.T) {
 	poem := &domain.Poem{ID: poemID, AuthorID: authorID}
 
 	comments.On("Create", mock.Anything, mock.AnythingOfType("*domain.Comment")).Return(nil)
-	poems.On("IncrementCounter", mock.Anything, poemID, "comment_count", 1).Return(nil)
 	poems.On("GetByID", mock.Anything, poemID).Return(poem, nil)
 	notifs.On("Create", mock.Anything, mock.AnythingOfType("*domain.Notification")).Return(nil)
 
@@ -214,7 +206,6 @@ func TestSocialService_DeleteComment_Success(t *testing.T) {
 
 	comments.On("GetByID", mock.Anything, commentID).Return(comment, nil)
 	comments.On("Delete", mock.Anything, commentID).Return(nil)
-	poems.On("IncrementCounter", mock.Anything, poemID, "comment_count", -1).Return(nil)
 
 	err := svc.DeleteComment(context.Background(), userID, commentID)
 	require.NoError(t, err)


### PR DESCRIPTION
Two backend correctness fixes, verified green (go build/vet/test).

- **#56** ReviewStanza now loads the poem's stanzas and rejects a stanza that isn't in this poem or isn't pending, so an author can't review a foreign stanza and re-approving can't double-count. Added foreign-stanza and already-reviewed tests.
- **#58** like toggle + counter now run in one repo transaction (delete, else insert on conflict), and comment create/delete update comment_count in the same transaction, so counts can't drift under concurrency or partial failure. Updated the like/comment tests to the new store shape.

Fixes #56, #58.