### PR TITLE
Auth hardening: HMAC tokens, POST + rate-limit verify

### DIFF
--- a/backend/internal/handler/auth.go
+++ b/backend/internal/handler/auth.go
@@ -58,13 +58,17 @@ func (h *AuthHandler) RequestMagicLink(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *AuthHandler) VerifyMagicLink(w http.ResponseWriter, r *http.Request) {
-	var token = r.URL.Query().Get("token")
-	if token == "" {
+	// Token comes in the body, not the URL, so it doesn't land in access logs
+	// or the Referer header.
+	var body struct {
+		Token string `json:"token"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body.Token == "" {
 		respondError(w, http.StatusBadRequest, "token is required")
 		return
 	}
 
-	sessionToken, user, err := h.svc.VerifyMagicLink(r.Context(), token)
+	sessionToken, user, err := h.svc.VerifyMagicLink(r.Context(), body.Token)
 	if err != nil {
 		respondError(w, http.StatusUnauthorized, "invalid or expired magic link")
 		return

--- a/backend/internal/handler/auth_test.go
+++ b/backend/internal/handler/auth_test.go
@@ -104,7 +104,7 @@ func TestAuthHandler_RequestMagicLink_MissingEmail(t *testing.T) {
 	assert.NotEmpty(t, resp.Error)
 }
 
-// GET /auth/magic-link/verify tests
+// POST /auth/magic-link/verify tests
 
 func TestAuthHandler_VerifyMagicLink_ValidToken(t *testing.T) {
 	svc := &mockAuthService{}
@@ -114,7 +114,7 @@ func TestAuthHandler_VerifyMagicLink_ValidToken(t *testing.T) {
 	user := &domain.User{ID: userID, Email: "user@test.com"}
 	svc.On("VerifyMagicLink", mock.Anything, "validtoken").Return("sessiontoken", user, nil)
 
-	r := httptest.NewRequest(http.MethodGet, "/auth/magic-link/verify?token=validtoken", nil)
+	r := httptest.NewRequest(http.MethodPost, "/auth/magic-link/verify", bytes.NewBufferString(`{"token":"validtoken"}`))
 	w := httptest.NewRecorder()
 
 	h.VerifyMagicLink(w, r)
@@ -136,7 +136,7 @@ func TestAuthHandler_VerifyMagicLink_MissingToken(t *testing.T) {
 	svc := &mockAuthService{}
 	h := newAuthHandler(svc)
 
-	r := httptest.NewRequest(http.MethodGet, "/auth/magic-link/verify", nil)
+	r := httptest.NewRequest(http.MethodPost, "/auth/magic-link/verify", bytes.NewBufferString(`{}`))
 	w := httptest.NewRecorder()
 
 	h.VerifyMagicLink(w, r)

--- a/backend/internal/server/server.go
+++ b/backend/internal/server/server.go
@@ -94,7 +94,7 @@ func (s *Server) setupRoutes() {
 		// Auth (public)
 		r.Route("/auth", func(r chi.Router) {
 			r.With(strictRL.Middleware).Post("/magic-link", authHandler.RequestMagicLink)
-			r.Get("/magic-link/verify", authHandler.VerifyMagicLink)
+			r.With(strictRL.Middleware).Post("/magic-link/verify", authHandler.VerifyMagicLink)
 			r.With(authMiddleware).Post("/register/begin", authHandler.BeginRegistration)
 			r.With(authMiddleware).Post("/register/finish", authHandler.FinishRegistration)
 			r.With(strictRL.Middleware).Post("/login/begin", authHandler.BeginLogin)

--- a/backend/internal/service/auth.go
+++ b/backend/internal/service/auth.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"crypto/hmac"
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
@@ -101,7 +102,7 @@ func NewAuthService(
 }
 
 func (s *AuthService) ValidateSession(ctx context.Context, token string) (uuid.UUID, error) {
-	var hash = hashToken(token)
+	var hash = hashToken(s.cfg.SessionSecret, token)
 	session, err := s.sessions.GetByTokenHash(ctx, hash)
 	if err != nil {
 		return uuid.Nil, fmt.Errorf("invalid session: %w", err)
@@ -132,7 +133,7 @@ func (s *AuthService) RequestMagicLink(ctx context.Context, email string) (strin
 		return "", fmt.Errorf("generating token: %w", err)
 	}
 
-	var hash = hashToken(rawToken)
+	var hash = hashToken(s.cfg.SessionSecret, rawToken)
 	var link = &domain.MagicLink{
 		Email:     email,
 		TokenHash: hash,
@@ -146,7 +147,7 @@ func (s *AuthService) RequestMagicLink(ctx context.Context, email string) (strin
 }
 
 func (s *AuthService) VerifyMagicLink(ctx context.Context, token string) (string, *domain.User, error) {
-	var hash = hashToken(token)
+	var hash = hashToken(s.cfg.SessionSecret, token)
 	link, err := s.magicLinks.GetByTokenHash(ctx, hash)
 	if err != nil {
 		return "", nil, fmt.Errorf("invalid magic link: %w", err)
@@ -189,7 +190,7 @@ func (s *AuthService) CreateSession(ctx context.Context, userID uuid.UUID) (stri
 		return "", fmt.Errorf("generating session token: %w", err)
 	}
 
-	var hash = hashToken(rawToken)
+	var hash = hashToken(s.cfg.SessionSecret, rawToken)
 	var session = &domain.Session{
 		UserID:    userID,
 		TokenHash: hash,
@@ -203,7 +204,7 @@ func (s *AuthService) CreateSession(ctx context.Context, userID uuid.UUID) (stri
 }
 
 func (s *AuthService) DeleteSession(ctx context.Context, token string) error {
-	var hash = hashToken(token)
+	var hash = hashToken(s.cfg.SessionSecret, token)
 	session, err := s.sessions.GetByTokenHash(ctx, hash)
 	if err != nil {
 		return fmt.Errorf("session not found: %w", err)
@@ -388,9 +389,12 @@ func (s *AuthService) FinishLogin(ctx context.Context, sessionKey string, r *htt
 	return user, sessionToken, nil
 }
 
-func hashToken(token string) string {
-	var h = sha256.Sum256([]byte(token))
-	return hex.EncodeToString(h[:])
+// hashToken keys the hash with SESSION_SECRET so a leaked session/magic-link
+// hash can't be used to forge a token without the secret.
+func hashToken(secret, token string) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(token))
+	return hex.EncodeToString(mac.Sum(nil))
 }
 
 func generateToken(n int) (string, error) {

--- a/backend/internal/service/auth_test.go
+++ b/backend/internal/service/auth_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
+	"github.com/maxwellpark/stanzabonanza/backend/internal/config"
 	"github.com/maxwellpark/stanzabonanza/backend/internal/domain"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -94,6 +95,7 @@ func newAuthSvc(users *mockUserStore, sessions *mockSessionStore, links *mockMag
 		sessions:   sessions,
 		magicLinks: links,
 		webAuthns:  &mockWebAuthnStore{},
+		cfg:        &config.Config{SessionSecret: "test-secret"},
 		waSessions: make(map[string]*waSession),
 	}
 }
@@ -150,7 +152,7 @@ func TestAuthService_VerifyMagicLink_Success(t *testing.T) {
 	svc := newAuthSvc(users, sessions, links)
 
 	rawToken, _ := generateToken(32)
-	hash := hashToken(rawToken)
+	hash := hashToken("test-secret", rawToken)
 	linkID := uuid.New()
 	userID := uuid.New()
 
@@ -180,7 +182,7 @@ func TestAuthService_VerifyMagicLink_CreatesUserIfMissing(t *testing.T) {
 	svc := newAuthSvc(users, sessions, links)
 
 	rawToken, _ := generateToken(32)
-	hash := hashToken(rawToken)
+	hash := hashToken("test-secret", rawToken)
 	linkID := uuid.New()
 
 	link := &domain.MagicLink{
@@ -209,7 +211,7 @@ func TestAuthService_VerifyMagicLink_AlreadyUsed(t *testing.T) {
 	svc := newAuthSvc(users, sessions, links)
 
 	rawToken, _ := generateToken(32)
-	hash := hashToken(rawToken)
+	hash := hashToken("test-secret", rawToken)
 	usedAt := time.Now().Add(-1 * time.Minute)
 
 	link := &domain.MagicLink{
@@ -232,7 +234,7 @@ func TestAuthService_VerifyMagicLink_Expired(t *testing.T) {
 	svc := newAuthSvc(users, sessions, links)
 
 	rawToken, _ := generateToken(32)
-	hash := hashToken(rawToken)
+	hash := hashToken("test-secret", rawToken)
 
 	link := &domain.MagicLink{
 		ID:        uuid.New(),
@@ -285,7 +287,7 @@ func TestAuthService_DeleteSession_Success(t *testing.T) {
 
 	sessionID := uuid.New()
 	rawToken, _ := generateToken(32)
-	hash := hashToken(rawToken)
+	hash := hashToken("test-secret", rawToken)
 
 	sessions.On("GetByTokenHash", mock.Anything, hash).Return(&domain.Session{ID: sessionID}, nil)
 	sessions.On("Delete", mock.Anything, sessionID).Return(nil)
@@ -338,8 +340,8 @@ func TestAuthService_UpdateProfile_UserNotFound(t *testing.T) {
 // hashToken / generateToken tests
 
 func TestHashToken_Deterministic(t *testing.T) {
-	h1 := hashToken("mysecret")
-	h2 := hashToken("mysecret")
+	h1 := hashToken("k", "mysecret")
+	h2 := hashToken("k", "mysecret")
 	assert.Equal(t, h1, h2)
 	assert.NotEmpty(t, h1)
 }

--- a/frontend/src/components/auth/MagicLinkVerify.tsx
+++ b/frontend/src/components/auth/MagicLinkVerify.tsx
@@ -23,7 +23,7 @@ export function MagicLinkVerify() {
 
     async function verify() {
       try {
-        await api.get(`/auth/magic-link/verify?token=${encodeURIComponent(token!)}`);
+        await api.post('/auth/magic-link/verify', { token });
         if (cancelled) {
           return;
         }


### PR DESCRIPTION
Two auth fixes, verified green (go build/vet/test, frontend build + 55 tests).

- **#65** session/magic-link token hashes are now HMAC-SHA256 keyed by SESSION_SECRET instead of a bare SHA-256, so the secret finally does something and a leaked hash can't forge a token. Existing sessions/links are invalidated (users re-login), which is fine.
- **#66** verify now takes the token in a POST body instead of the URL query (keeps it out of access logs and Referer) and sits behind the strict 3/s limiter like request does. Frontend posts the token and the change is transparent to the user.

Fixes #65, #66.