### PR TITLE
Like state (likedByMe) and a React error boundary

### DIFF
--- a/backend/internal/domain/poem.go
+++ b/backend/internal/domain/poem.go
@@ -40,6 +40,7 @@ type Poem struct {
 	LikeCount       int          `json:"likeCount"`
 	StanzaCount     int          `json:"stanzaCount"`
 	CommentCount    int          `json:"commentCount"`
+	LikedByMe       bool         `json:"likedByMe"` // set on the detail view for the current user
 	Stanzas         []Stanza     `json:"stanzas,omitempty"`
 	CreatedAt       time.Time    `json:"createdAt"`
 	UpdatedAt       time.Time    `json:"updatedAt"`

--- a/backend/internal/handler/poem.go
+++ b/backend/internal/handler/poem.go
@@ -14,7 +14,7 @@ import (
 
 type poemService interface {
 	Create(ctx context.Context, userID uuid.UUID, title, description string, format domain.PoemFormat, approvalMode domain.ApprovalMode, maxStanzas *int) (*domain.Poem, error)
-	Get(ctx context.Context, id uuid.UUID) (*domain.Poem, error)
+	Get(ctx context.Context, id, viewerID uuid.UUID) (*domain.Poem, error)
 	List(ctx context.Context, page domain.PaginationParams, format, sort string) ([]domain.Poem, int, error)
 	ListByUser(ctx context.Context, userID uuid.UUID, page domain.PaginationParams) ([]domain.Poem, int, error)
 	Update(ctx context.Context, userID, poemID uuid.UUID, title, description string) error
@@ -86,7 +86,8 @@ func (h *PoemHandler) Get(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	poem, err := h.svc.Get(r.Context(), poemID)
+	viewerID, _ := middleware.UserIDFromContext(r.Context())
+	poem, err := h.svc.Get(r.Context(), poemID, viewerID)
 	if err != nil {
 		respondError(w, http.StatusNotFound, "poem not found")
 		return

--- a/backend/internal/handler/poem_test.go
+++ b/backend/internal/handler/poem_test.go
@@ -25,8 +25,8 @@ func (m *mockPoemService) Create(ctx context.Context, userID uuid.UUID, title, d
 	p, _ := args.Get(0).(*domain.Poem)
 	return p, args.Error(1)
 }
-func (m *mockPoemService) Get(ctx context.Context, id uuid.UUID) (*domain.Poem, error) {
-	args := m.Called(ctx, id)
+func (m *mockPoemService) Get(ctx context.Context, id, viewerID uuid.UUID) (*domain.Poem, error) {
+	args := m.Called(ctx, id, viewerID)
 	p, _ := args.Get(0).(*domain.Poem)
 	return p, args.Error(1)
 }
@@ -152,7 +152,7 @@ func TestPoemHandler_Get_ValidID(t *testing.T) {
 
 	poemID := uuid.New()
 	poem := &domain.Poem{ID: poemID, Title: "Found"}
-	svc.On("Get", mock.Anything, poemID).Return(poem, nil)
+	svc.On("Get", mock.Anything, poemID, uuid.Nil).Return(poem, nil)
 
 	r := httptest.NewRequest(http.MethodGet, "/poems/"+poemID.String(), nil)
 	rctx := chi.NewRouteContext()

--- a/backend/internal/server/server.go
+++ b/backend/internal/server/server.go
@@ -73,7 +73,7 @@ func (s *Server) setupRoutes() {
 	tutorialRepo := repository.NewTutorialRepository(s.db)
 
 	authSvc := service.NewAuthService(userRepo, sessionRepo, magicLinkRepo, webAuthnRepo, s.cfg)
-	poemSvc := service.NewPoemService(poemRepo, stanzaRepo, notifRepo)
+	poemSvc := service.NewPoemService(poemRepo, stanzaRepo, notifRepo, likeRepo)
 	socialSvc := service.NewSocialService(likeRepo, commentRepo, followRepo, notifRepo, poemRepo)
 	tutorialSvc := service.NewTutorialService(tutorialRepo)
 

--- a/backend/internal/service/poem.go
+++ b/backend/internal/service/poem.go
@@ -33,17 +33,23 @@ type poemNotifStore interface {
 	Create(ctx context.Context, notif *domain.Notification) error
 }
 
+type likeChecker interface {
+	Exists(ctx context.Context, userID, poemID uuid.UUID) (bool, error)
+}
+
 type PoemService struct {
 	poems   poemStore
 	stanzas stanzaStore
 	notifs  poemNotifStore
+	likes   likeChecker
 }
 
-func NewPoemService(poems *repository.PoemRepository, stanzas *repository.StanzaRepository, notifs *repository.NotificationRepository) *PoemService {
+func NewPoemService(poems *repository.PoemRepository, stanzas *repository.StanzaRepository, notifs *repository.NotificationRepository, likes *repository.LikeRepository) *PoemService {
 	return &PoemService{
 		poems:   poems,
 		stanzas: stanzas,
 		notifs:  notifs,
+		likes:   likes,
 	}
 }
 
@@ -64,7 +70,7 @@ func (s *PoemService) Create(ctx context.Context, userID uuid.UUID, title, descr
 	return poem, nil
 }
 
-func (s *PoemService) Get(ctx context.Context, id uuid.UUID) (*domain.Poem, error) {
+func (s *PoemService) Get(ctx context.Context, id, viewerID uuid.UUID) (*domain.Poem, error) {
 	poem, err := s.poems.GetByID(ctx, id)
 	if err != nil {
 		return nil, fmt.Errorf("poem not found: %w", err)
@@ -75,6 +81,12 @@ func (s *PoemService) Get(ctx context.Context, id uuid.UUID) (*domain.Poem, erro
 		return nil, fmt.Errorf("loading stanzas: %w", err)
 	}
 	poem.Stanzas = stanzas
+
+	if viewerID != uuid.Nil && s.likes != nil {
+		if liked, err := s.likes.Exists(ctx, viewerID, id); err == nil {
+			poem.LikedByMe = liked
+		}
+	}
 
 	return poem, nil
 }

--- a/backend/internal/service/poem_test.go
+++ b/backend/internal/service/poem_test.go
@@ -134,7 +134,7 @@ func TestPoemService_Get_Success(t *testing.T) {
 	poems.On("GetByID", mock.Anything, poemID).Return(expected, nil)
 	stanzas.On("ListByPoem", mock.Anything, poemID).Return(stanzaList, nil)
 
-	poem, err := svc.Get(context.Background(), poemID)
+	poem, err := svc.Get(context.Background(), poemID, uuid.Nil)
 	require.NoError(t, err)
 	assert.Equal(t, "My Poem", poem.Title)
 	assert.Len(t, poem.Stanzas, 1)
@@ -146,7 +146,7 @@ func TestPoemService_Get_NotFound(t *testing.T) {
 
 	poems.On("GetByID", mock.Anything, mock.Anything).Return(nil, errors.New("no rows"))
 
-	_, err := svc.Get(context.Background(), uuid.New())
+	_, err := svc.Get(context.Background(), uuid.New(), uuid.Nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "poem not found")
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 import { RouterProvider } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { router } from '@/router';
+import { ErrorBoundary } from '@/components/ErrorBoundary';
 import { useAuthStore } from '@/stores/authStore';
 
 var queryClient = new QueryClient({
@@ -27,7 +28,9 @@ export default function App() {
   return (
     <QueryClientProvider client={queryClient}>
       <AuthInit />
-      <RouterProvider router={router} />
+      <ErrorBoundary>
+        <RouterProvider router={router} />
+      </ErrorBoundary>
     </QueryClientProvider>
   );
 }

--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -1,0 +1,43 @@
+import { Component, type ErrorInfo, type ReactNode } from 'react';
+
+interface Props {
+  children: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+}
+
+// Catches render-time throws so a bad API payload can't blank the whole app.
+export class ErrorBoundary extends Component<Props, State> {
+  state: State = { hasError: false };
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error('Uncaught render error:', error, info);
+  }
+
+  render() {
+    if (!this.state.hasError) {
+      return this.props.children;
+    }
+
+    return (
+      <div className="flex min-h-[50vh] items-center justify-center">
+        <div className="card max-w-md text-center">
+          <div className="mb-4 text-3xl text-error">!</div>
+          <h2 className="mb-2 font-serif text-lg font-bold text-ink">Something went wrong</h2>
+          <p className="mb-4 text-sm text-feather">
+            The page hit an unexpected error. Reloading usually sorts it.
+          </p>
+          <button className="btn-primary" onClick={() => window.location.reload()}>
+            Reload
+          </button>
+        </div>
+      </div>
+    );
+  }
+}

--- a/frontend/src/components/poem/PoemDetail.tsx
+++ b/frontend/src/components/poem/PoemDetail.tsx
@@ -85,7 +85,7 @@ export function PoemDetail({ poem }: PoemDetailProps) {
       </div>
 
       <div className="mb-8 flex items-center gap-4">
-        <LikeButton poemId={poem.id} likeCount={poem.likeCount} />
+        <LikeButton poemId={poem.id} likeCount={poem.likeCount} isLiked={poem.likedByMe} />
 
         <span className="flex items-center gap-1 font-sans text-sm text-feather">
           <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>

--- a/frontend/src/components/social/LikeButton.tsx
+++ b/frontend/src/components/social/LikeButton.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useToggleLike } from '@/hooks/useSocial';
 import { useAuthStore } from '@/stores/authStore';
@@ -17,6 +17,16 @@ export function LikeButton({ poemId, likeCount, isLiked: initialLiked }: LikeBut
   var mutation = useToggleLike(poemId);
   var { isAuthenticated } = useAuthStore();
   var { openLogin } = useUIStore();
+
+  // Resync to server truth when fresh props arrive (e.g. after a refetch),
+  // but not mid-mutation or the optimistic update would be clobbered.
+  useEffect(() => {
+    if (mutation.isPending) {
+      return;
+    }
+    setOptimisticLiked(initialLiked ?? false);
+    setOptimisticCount(likeCount);
+  }, [initialLiked, likeCount, mutation.isPending]);
 
   function handleClick() {
     if (!isAuthenticated) {

--- a/frontend/src/types/poem.ts
+++ b/frontend/src/types/poem.ts
@@ -27,6 +27,7 @@ export interface Poem {
   likeCount: number;
   stanzaCount: number;
   commentCount: number;
+  likedByMe?: boolean;
   stanzas?: Stanza[];
   createdAt: string;
   updatedAt: string;


### PR DESCRIPTION
Verified green (go build/vet/test, frontend build + 55 tests).

- **#57** poem detail now returns `likedByMe` for the current viewer (a like lookup on the detail path only, lists are untouched), and the like button renders with it, so an already-liked poem shows a filled heart.
- **#63** the like button resyncs its optimistic count/liked from props after a refetch instead of ignoring them, so the count can no longer drift.
- **#64** an error boundary wraps the router with a reload fallback, so a render-time throw no longer blanks the app.

Fixes #57, #63, #64.