### PR TITLE
Sweep idle rate-limit and abandoned WebAuthn state

### DIFF
--- a/backend/internal/middleware/ratelimit.go
+++ b/backend/internal/middleware/ratelimit.go
@@ -4,35 +4,65 @@ import (
 	"net"
 	"net/http"
 	"sync"
+	"time"
 
 	"golang.org/x/time/rate"
 )
 
+// visitorTTL is how long an idle visitor's limiter is kept before eviction.
+const visitorTTL = 10 * time.Minute
+
+type visitor struct {
+	limiter  *rate.Limiter
+	lastSeen time.Time
+}
+
 type RateLimiter struct {
-	visitors map[string]*rate.Limiter
+	visitors map[string]*visitor
 	mu       sync.Mutex
 	rate     rate.Limit
 	burst    int
 }
 
 func NewRateLimiter(r rate.Limit, burst int) *RateLimiter {
-	return &RateLimiter{
-		visitors: make(map[string]*rate.Limiter),
+	rl := &RateLimiter{
+		visitors: make(map[string]*visitor),
 		rate:     r,
 		burst:    burst,
 	}
+	go rl.sweep()
+	return rl
 }
 
 func (rl *RateLimiter) getLimiter(ip string) *rate.Limiter {
 	rl.mu.Lock()
 	defer rl.mu.Unlock()
 
-	limiter, exists := rl.visitors[ip]
+	v, exists := rl.visitors[ip]
 	if !exists {
-		limiter = rate.NewLimiter(rl.rate, rl.burst)
-		rl.visitors[ip] = limiter
+		v = &visitor{limiter: rate.NewLimiter(rl.rate, rl.burst)}
+		rl.visitors[ip] = v
 	}
-	return limiter
+	v.lastSeen = time.Now()
+	return v.limiter
+}
+
+// sweep evicts idle visitors so the map can't grow without bound.
+func (rl *RateLimiter) sweep() {
+	ticker := time.NewTicker(visitorTTL)
+	for range ticker.C {
+		rl.cleanup(time.Now())
+	}
+}
+
+func (rl *RateLimiter) cleanup(now time.Time) {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+	for ip, v := range rl.visitors {
+		if now.Sub(v.lastSeen) > visitorTTL {
+			delete(rl.visitors, ip)
+		}
+	}
 }
 
 func (rl *RateLimiter) Middleware(next http.Handler) http.Handler {

--- a/backend/internal/middleware/ratelimit_test.go
+++ b/backend/internal/middleware/ratelimit_test.go
@@ -1,0 +1,23 @@
+package middleware
+
+import (
+	"testing"
+	"time"
+)
+
+func TestRateLimiter_CleanupEvictsIdle(t *testing.T) {
+	rl := &RateLimiter{visitors: map[string]*visitor{}, rate: 1, burst: 1}
+
+	rl.getLimiter("1.2.3.4")
+	rl.visitors["1.2.3.4"].lastSeen = time.Now().Add(-2 * visitorTTL)
+	rl.getLimiter("5.6.7.8")
+
+	rl.cleanup(time.Now())
+
+	if _, ok := rl.visitors["1.2.3.4"]; ok {
+		t.Fatal("idle visitor should be evicted")
+	}
+	if _, ok := rl.visitors["5.6.7.8"]; !ok {
+		t.Fatal("recent visitor should remain")
+	}
+}

--- a/backend/internal/service/auth.go
+++ b/backend/internal/service/auth.go
@@ -90,7 +90,7 @@ func NewAuthService(
 		RPID:          cfg.WebAuthnRPID,
 		RPOrigins:     cfg.WebAuthnOrigins,
 	})
-	return &AuthService{
+	svc := &AuthService{
 		users:      users,
 		sessions:   sessions,
 		magicLinks: magicLinks,
@@ -99,6 +99,8 @@ func NewAuthService(
 		cfg:        cfg,
 		waSessions: make(map[string]*waSession),
 	}
+	go svc.sweepWASessions()
+	return svc
 }
 
 func (s *AuthService) ValidateSession(ctx context.Context, token string) (uuid.UUID, error) {
@@ -245,6 +247,26 @@ func (s *AuthService) popWASession(key string) (*webauthn.SessionData, bool) {
 	}
 	delete(s.waSessions, key)
 	return sess.data, true
+}
+
+// sweepWASessions evicts abandoned (never-consumed) ceremonies so the map
+// can't grow without bound. Cross-machine correctness still needs a shared
+// store; this only bounds the single-process leak.
+func (s *AuthService) sweepWASessions() {
+	ticker := time.NewTicker(5 * time.Minute)
+	for range ticker.C {
+		s.cleanupWASessions(time.Now())
+	}
+}
+
+func (s *AuthService) cleanupWASessions(now time.Time) {
+	s.waMu.Lock()
+	defer s.waMu.Unlock()
+	for k, sess := range s.waSessions {
+		if now.After(sess.expiresAt) {
+			delete(s.waSessions, k)
+		}
+	}
 }
 
 func (s *AuthService) buildWebAuthnUser(ctx context.Context, user *domain.User) (*webAuthnUser, error) {

--- a/backend/internal/service/auth_test.go
+++ b/backend/internal/service/auth_test.go
@@ -355,3 +355,16 @@ func TestGenerateToken_UniqueOutputs(t *testing.T) {
 	// 32 bytes hex-encoded = 64 chars.
 	assert.Len(t, t1, 64)
 }
+
+func TestAuthService_CleanupWASessions(t *testing.T) {
+	svc := newAuthSvc(&mockUserStore{}, &mockSessionStore{}, &mockMagicLinkStore{})
+	svc.waSessions["expired"] = &waSession{expiresAt: time.Now().Add(-time.Minute)}
+	svc.waSessions["live"] = &waSession{expiresAt: time.Now().Add(time.Minute)}
+
+	svc.cleanupWASessions(time.Now())
+
+	_, expiredOK := svc.waSessions["expired"]
+	assert.False(t, expiredOK, "expired ceremony should be evicted")
+	_, liveOK := svc.waSessions["live"]
+	assert.True(t, liveOK, "live ceremony should remain")
+}


### PR DESCRIPTION
Verified green (go build/vet/test, new middleware test).

Both in-memory maps grew without bound: rate-limit `visitors` kept a limiter per client IP forever, and `waSessions` leaked any WebAuthn ceremony that was begun but never finished. Each now tracks last-seen / expiry and a background sweeper evicts stale entries.

Cross-machine correctness (auto_start_machines running >1 machine, where a ceremony can begin on one and finish on another) still needs a shared store, e.g. Redis or Postgres. Called that out in the code so it is not forgotten; single-machine is now bounded.

Fixes #62.