### PR TITLE
Send the magic-link login email via Resend

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ Backend config lives in `backend/internal/config/config.go`, set via env or a `.
 | `PORT` | no | `8080` |
 | `ALLOWED_ORIGINS` | no | `http://localhost:5173` |
 | `WEBAUTHN_RP_ID` / `WEBAUTHN_RP_NAME` / `WEBAUTHN_RP_ORIGINS` | no | localhost defaults |
-| `RESEND_API_KEY` | for magic-link email | — |
+| `RESEND_API_KEY` | for magic-link email | — (no key: link is logged, not sent) |
+| `EMAIL_FROM` | no | `Stanza Bonanza <onboarding@resend.dev>` |
 | `MAGIC_LINK_BASE_URL` | no | `http://localhost:5173/auth/verify` |
 
 ## Deploy

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -14,6 +14,7 @@ type Config struct {
 	WebAuthnRPName   string   `envconfig:"WEBAUTHN_RP_NAME" default:"StanzaBonanza"`
 	WebAuthnOrigins  []string `envconfig:"WEBAUTHN_RP_ORIGINS" default:"http://localhost:5173"`
 	ResendAPIKey     string   `envconfig:"RESEND_API_KEY"`
+	EmailFrom        string   `envconfig:"EMAIL_FROM" default:"Stanza Bonanza <onboarding@resend.dev>"`
 	MagicLinkBaseURL string   `envconfig:"MAGIC_LINK_BASE_URL" default:"http://localhost:5173/auth/verify"`
 }
 

--- a/backend/internal/service/auth.go
+++ b/backend/internal/service/auth.go
@@ -8,8 +8,10 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"log"
 	"net/http"
 	"net/mail"
+	"net/url"
 	"strings"
 	"sync"
 	"time"
@@ -73,6 +75,7 @@ type AuthService struct {
 	webAuthns  webAuthnStore
 	wac        *webauthn.WebAuthn
 	cfg        *config.Config
+	mailer     Mailer
 
 	waMu       sync.Mutex
 	waSessions map[string]*waSession
@@ -98,6 +101,9 @@ func NewAuthService(
 		wac:        wac,
 		cfg:        cfg,
 		waSessions: make(map[string]*waSession),
+	}
+	if cfg.ResendAPIKey != "" {
+		svc.mailer = NewResendMailer(cfg.ResendAPIKey, cfg.EmailFrom)
 	}
 	go svc.sweepWASessions()
 	return svc
@@ -143,6 +149,17 @@ func (s *AuthService) RequestMagicLink(ctx context.Context, email string) (strin
 	}
 	if err := s.magicLinks.Create(ctx, link); err != nil {
 		return "", fmt.Errorf("storing magic link: %w", err)
+	}
+
+	verifyURL := s.cfg.MagicLinkBaseURL + "?token=" + url.QueryEscape(rawToken)
+	if s.mailer != nil {
+		if err := s.mailer.SendMagicLink(ctx, email, verifyURL); err != nil {
+			log.Printf("sending magic link to %s: %v", email, err)
+			return "", fmt.Errorf("sending magic link: %w", err)
+		}
+	} else {
+		// No RESEND_API_KEY (dev): log the link so local login still works.
+		log.Printf("magic link for %s: %s", email, verifyURL)
 	}
 
 	return rawToken, nil

--- a/backend/internal/service/auth_test.go
+++ b/backend/internal/service/auth_test.go
@@ -89,6 +89,12 @@ func (m *mockWebAuthnStore) UpdateSignCount(ctx context.Context, credentialID []
 	return m.Called(ctx, credentialID, signCount).Error(0)
 }
 
+type mockMailer struct{ mock.Mock }
+
+func (m *mockMailer) SendMagicLink(ctx context.Context, to, link string) error {
+	return m.Called(ctx, to, link).Error(0)
+}
+
 func newAuthSvc(users *mockUserStore, sessions *mockSessionStore, links *mockMagicLinkStore) *AuthService {
 	return &AuthService{
 		users:      users,
@@ -115,6 +121,20 @@ func TestAuthService_RequestMagicLink_DoesNotCreateUser(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotEmpty(t, token)
 	users.AssertNotCalled(t, "Create", mock.Anything, mock.Anything)
+}
+
+func TestAuthService_RequestMagicLink_SendsEmailWhenMailerSet(t *testing.T) {
+	links := &mockMagicLinkStore{}
+	svc := newAuthSvc(&mockUserStore{}, &mockSessionStore{}, links)
+	mailer := &mockMailer{}
+	svc.mailer = mailer
+
+	links.On("Create", mock.Anything, mock.AnythingOfType("*domain.MagicLink")).Return(nil)
+	mailer.On("SendMagicLink", mock.Anything, "user@test.com", mock.Anything).Return(nil)
+
+	_, err := svc.RequestMagicLink(context.Background(), "user@test.com")
+	require.NoError(t, err)
+	mailer.AssertCalled(t, "SendMagicLink", mock.Anything, "user@test.com", mock.Anything)
 }
 
 func TestAuthService_RequestMagicLink_RejectsInvalidEmail(t *testing.T) {

--- a/backend/internal/service/mailer.go
+++ b/backend/internal/service/mailer.go
@@ -1,0 +1,58 @@
+package service
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+// Mailer sends the magic-link login email.
+type Mailer interface {
+	SendMagicLink(ctx context.Context, to, link string) error
+}
+
+// ResendMailer sends via the Resend HTTP API (no SDK dependency).
+type ResendMailer struct {
+	apiKey string
+	from   string
+	client *http.Client
+}
+
+func NewResendMailer(apiKey, from string) *ResendMailer {
+	return &ResendMailer{apiKey: apiKey, from: from, client: &http.Client{Timeout: 10 * time.Second}}
+}
+
+func (m *ResendMailer) SendMagicLink(ctx context.Context, to, link string) error {
+	payload, err := json.Marshal(map[string]any{
+		"from":    m.from,
+		"to":      []string{to},
+		"subject": "Your Stanza Bonanza login link",
+		"html": fmt.Sprintf(
+			`<p>Sign in to Stanza Bonanza:</p><p><a href="%s">Sign in</a></p><p>This link expires in 15 minutes. If you didn't request it, ignore this email.</p>`,
+			link,
+		),
+	})
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "https://api.resend.com/emails", bytes.NewReader(payload))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+m.apiKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := m.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("resend returned %d", resp.StatusCode)
+	}
+	return nil
+}


### PR DESCRIPTION
Verified green (go build/vet/test). This is the last of the 14 review items.

RequestMagicLink now sends the verify link by email through the Resend HTTP API (no SDK dependency). The link points at `MAGIC_LINK_BASE_URL?token=...`, which the SPA reads and POSTs to verify (matches the #66 change).

**Needs config to actually send:** set `RESEND_API_KEY` and a verified `EMAIL_FROM` in Fly. With no key set (local dev) the link is logged instead of sent, so login still works locally. Added both to the README env table.

Fixes #53.