### PR TITLE
Poem search and tags (backend)

### DIFF
--- a/backend/internal/domain/poem.go
+++ b/backend/internal/domain/poem.go
@@ -41,6 +41,7 @@ type Poem struct {
 	StanzaCount     int          `json:"stanzaCount"`
 	CommentCount    int          `json:"commentCount"`
 	LikedByMe       bool         `json:"likedByMe"` // set on the detail view for the current user
+	Tags            []string     `json:"tags"`
 	Stanzas         []Stanza     `json:"stanzas,omitempty"`
 	CreatedAt       time.Time    `json:"createdAt"`
 	UpdatedAt       time.Time    `json:"updatedAt"`

--- a/backend/internal/handler/poem.go
+++ b/backend/internal/handler/poem.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"strings"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
@@ -13,11 +14,11 @@ import (
 )
 
 type poemService interface {
-	Create(ctx context.Context, userID uuid.UUID, title, description string, format domain.PoemFormat, approvalMode domain.ApprovalMode, maxStanzas *int) (*domain.Poem, error)
+	Create(ctx context.Context, userID uuid.UUID, title, description string, format domain.PoemFormat, approvalMode domain.ApprovalMode, maxStanzas *int, tags []string) (*domain.Poem, error)
 	Get(ctx context.Context, id, viewerID uuid.UUID) (*domain.Poem, error)
-	List(ctx context.Context, page domain.PaginationParams, format, sort string) ([]domain.Poem, int, error)
+	List(ctx context.Context, page domain.PaginationParams, format, sort, q, tag string) ([]domain.Poem, int, error)
 	ListByUser(ctx context.Context, userID uuid.UUID, page domain.PaginationParams) ([]domain.Poem, int, error)
-	Update(ctx context.Context, userID, poemID uuid.UUID, title, description string) error
+	Update(ctx context.Context, userID, poemID uuid.UUID, title, description string, tags []string) error
 	Delete(ctx context.Context, userID, poemID uuid.UUID) error
 	ListStanzas(ctx context.Context, poemID uuid.UUID) ([]domain.Stanza, error)
 	SubmitStanza(ctx context.Context, userID, poemID uuid.UUID, text, literaryDevice string) (*domain.Stanza, error)
@@ -48,6 +49,7 @@ func (h *PoemHandler) Create(w http.ResponseWriter, r *http.Request) {
 		Format       domain.PoemFormat  `json:"format"`
 		ApprovalMode domain.ApprovalMode `json:"approvalMode"`
 		MaxStanzas   *int               `json:"maxStanzas"`
+		Tags         []string           `json:"tags"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		respondError(w, http.StatusBadRequest, "invalid request body")
@@ -62,6 +64,10 @@ func (h *PoemHandler) Create(w http.ResponseWriter, r *http.Request) {
 		respondError(w, http.StatusBadRequest, "title must be 200 characters or fewer")
 		return
 	}
+	if len(body.Tags) > 10 {
+		respondError(w, http.StatusBadRequest, "a poem can have at most 10 tags")
+		return
+	}
 	if body.Format == "" {
 		respondError(w, http.StatusBadRequest, "format is required")
 		return
@@ -70,7 +76,7 @@ func (h *PoemHandler) Create(w http.ResponseWriter, r *http.Request) {
 		body.ApprovalMode = domain.ApprovalOpen
 	}
 
-	poem, err := h.svc.Create(r.Context(), userID, body.Title, body.Description, body.Format, body.ApprovalMode, body.MaxStanzas)
+	poem, err := h.svc.Create(r.Context(), userID, body.Title, body.Description, body.Format, body.ApprovalMode, body.MaxStanzas, body.Tags)
 	if err != nil {
 		respondError(w, http.StatusInternalServerError, "failed to create poem")
 		return
@@ -100,8 +106,10 @@ func (h *PoemHandler) List(w http.ResponseWriter, r *http.Request) {
 	var page = parsePagination(r)
 	var format = r.URL.Query().Get("format")
 	var sort = r.URL.Query().Get("sort")
+	var q = strings.TrimSpace(r.URL.Query().Get("q"))
+	var tag = r.URL.Query().Get("tag")
 
-	poems, total, err := h.svc.List(r.Context(), page, format, sort)
+	poems, total, err := h.svc.List(r.Context(), page, format, sort, q, tag)
 	if err != nil {
 		respondError(w, http.StatusInternalServerError, "failed to list poems")
 		return
@@ -151,8 +159,9 @@ func (h *PoemHandler) Update(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var body struct {
-		Title       string `json:"title"`
-		Description string `json:"description"`
+		Title       string   `json:"title"`
+		Description string   `json:"description"`
+		Tags        []string `json:"tags"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		respondError(w, http.StatusBadRequest, "invalid request body")
@@ -167,8 +176,12 @@ func (h *PoemHandler) Update(w http.ResponseWriter, r *http.Request) {
 		respondError(w, http.StatusBadRequest, "title must be 200 characters or fewer")
 		return
 	}
+	if len(body.Tags) > 10 {
+		respondError(w, http.StatusBadRequest, "a poem can have at most 10 tags")
+		return
+	}
 
-	if err := h.svc.Update(r.Context(), userID, poemID, body.Title, body.Description); err != nil {
+	if err := h.svc.Update(r.Context(), userID, poemID, body.Title, body.Description, body.Tags); err != nil {
 		if err.Error() == "not the poem author" {
 			respondError(w, http.StatusForbidden, "you are not the author of this poem")
 			return

--- a/backend/internal/handler/poem_test.go
+++ b/backend/internal/handler/poem_test.go
@@ -20,8 +20,8 @@ import (
 
 type mockPoemService struct{ mock.Mock }
 
-func (m *mockPoemService) Create(ctx context.Context, userID uuid.UUID, title, description string, format domain.PoemFormat, approvalMode domain.ApprovalMode, maxStanzas *int) (*domain.Poem, error) {
-	args := m.Called(ctx, userID, title, description, format, approvalMode, maxStanzas)
+func (m *mockPoemService) Create(ctx context.Context, userID uuid.UUID, title, description string, format domain.PoemFormat, approvalMode domain.ApprovalMode, maxStanzas *int, tags []string) (*domain.Poem, error) {
+	args := m.Called(ctx, userID, title, description, format, approvalMode, maxStanzas, tags)
 	p, _ := args.Get(0).(*domain.Poem)
 	return p, args.Error(1)
 }
@@ -30,8 +30,8 @@ func (m *mockPoemService) Get(ctx context.Context, id, viewerID uuid.UUID) (*dom
 	p, _ := args.Get(0).(*domain.Poem)
 	return p, args.Error(1)
 }
-func (m *mockPoemService) List(ctx context.Context, page domain.PaginationParams, format, sort string) ([]domain.Poem, int, error) {
-	args := m.Called(ctx, page, format, sort)
+func (m *mockPoemService) List(ctx context.Context, page domain.PaginationParams, format, sort, q, tag string) ([]domain.Poem, int, error) {
+	args := m.Called(ctx, page, format, sort, q, tag)
 	poems, _ := args.Get(0).([]domain.Poem)
 	return poems, args.Int(1), args.Error(2)
 }
@@ -40,8 +40,8 @@ func (m *mockPoemService) ListByUser(ctx context.Context, userID uuid.UUID, page
 	poems, _ := args.Get(0).([]domain.Poem)
 	return poems, args.Int(1), args.Error(2)
 }
-func (m *mockPoemService) Update(ctx context.Context, userID, poemID uuid.UUID, title, description string) error {
-	return m.Called(ctx, userID, poemID, title, description).Error(0)
+func (m *mockPoemService) Update(ctx context.Context, userID, poemID uuid.UUID, title, description string, tags []string) error {
+	return m.Called(ctx, userID, poemID, title, description, tags).Error(0)
 }
 func (m *mockPoemService) Delete(ctx context.Context, userID, poemID uuid.UUID) error {
 	return m.Called(ctx, userID, poemID).Error(0)
@@ -87,7 +87,7 @@ func TestPoemHandler_Create_ValidBody(t *testing.T) {
 
 	userID := uuid.New()
 	poem := &domain.Poem{ID: uuid.New(), Title: "My Poem", Format: domain.FormatFreeVerse}
-	svc.On("Create", mock.Anything, userID, "My Poem", "", domain.FormatFreeVerse, domain.ApprovalOpen, (*int)(nil)).Return(poem, nil)
+	svc.On("Create", mock.Anything, userID, "My Poem", "", domain.FormatFreeVerse, domain.ApprovalOpen, (*int)(nil), ([]string)(nil)).Return(poem, nil)
 
 	body := `{"title":"My Poem","format":"free_verse"}`
 	r := httptest.NewRequest(http.MethodPost, "/poems", bytes.NewBufferString(body))

--- a/backend/internal/repository/poem.go
+++ b/backend/internal/repository/poem.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -88,17 +89,32 @@ func (r *PoemRepository) GetByID(ctx context.Context, id uuid.UUID) (*domain.Poe
 	return scanPoem(r.pool.QueryRow(ctx, query, id))
 }
 
-func (r *PoemRepository) List(ctx context.Context, page domain.PaginationParams, format string, sort string) ([]domain.Poem, int, error) {
+func (r *PoemRepository) List(ctx context.Context, page domain.PaginationParams, format, sort, q, tag string) ([]domain.Poem, int, error) {
 	page.Normalize()
 
-	var where string
+	var conds []string
 	var args []any
 	var argIdx = 1
 
 	if format != "" {
-		where = fmt.Sprintf(" WHERE p.format = $%d", argIdx)
+		conds = append(conds, fmt.Sprintf("p.format = $%d", argIdx))
 		args = append(args, format)
 		argIdx++
+	}
+	if q != "" {
+		conds = append(conds, fmt.Sprintf("(p.title ILIKE $%d OR p.description ILIKE $%d OR u.display_name ILIKE $%d)", argIdx, argIdx, argIdx))
+		args = append(args, "%"+q+"%")
+		argIdx++
+	}
+	if tag != "" {
+		conds = append(conds, fmt.Sprintf("p.id IN (SELECT pt.poem_id FROM poem_tags pt JOIN tags t ON t.id = pt.tag_id WHERE t.slug = $%d)", argIdx))
+		args = append(args, tag)
+		argIdx++
+	}
+
+	var where string
+	if len(conds) > 0 {
+		where = " WHERE " + strings.Join(conds, " AND ")
 	}
 
 	var orderBy string

--- a/backend/internal/repository/tag.go
+++ b/backend/internal/repository/tag.go
@@ -1,0 +1,112 @@
+package repository
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+type TagRepository struct {
+	pool *pgxpool.Pool
+}
+
+func NewTagRepository(pool *pgxpool.Pool) *TagRepository {
+	return &TagRepository{pool: pool}
+}
+
+var nonSlugChars = regexp.MustCompile(`[^a-z0-9]+`)
+
+func slugify(name string) string {
+	s := strings.ToLower(strings.TrimSpace(name))
+	s = nonSlugChars.ReplaceAllString(s, "-")
+	return strings.Trim(s, "-")
+}
+
+// SetForPoem replaces a poem's tags with the given names, upserting the tags.
+func (r *TagRepository) SetForPoem(ctx context.Context, poemID uuid.UUID, names []string) error {
+	tx, err := r.pool.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback(ctx)
+
+	if _, err := tx.Exec(ctx, `DELETE FROM poem_tags WHERE poem_id = $1`, poemID); err != nil {
+		return err
+	}
+
+	seen := map[string]bool{}
+	for _, name := range names {
+		slug := slugify(name)
+		if slug == "" || seen[slug] {
+			continue
+		}
+		seen[slug] = true
+
+		var tagID uuid.UUID
+		err := tx.QueryRow(ctx,
+			`INSERT INTO tags (id, name, slug) VALUES ($1, $2, $3)
+			 ON CONFLICT (slug) DO UPDATE SET slug = EXCLUDED.slug
+			 RETURNING id`,
+			uuid.New(), strings.TrimSpace(name), slug,
+		).Scan(&tagID)
+		if err != nil {
+			return err
+		}
+		if _, err := tx.Exec(ctx,
+			`INSERT INTO poem_tags (poem_id, tag_id) VALUES ($1, $2) ON CONFLICT DO NOTHING`,
+			poemID, tagID,
+		); err != nil {
+			return err
+		}
+	}
+	return tx.Commit(ctx)
+}
+
+// ListForPoem returns a poem's tag slugs.
+func (r *TagRepository) ListForPoem(ctx context.Context, poemID uuid.UUID) ([]string, error) {
+	rows, err := r.pool.Query(ctx,
+		`SELECT t.slug FROM tags t JOIN poem_tags pt ON pt.tag_id = t.id
+		 WHERE pt.poem_id = $1 ORDER BY t.slug`, poemID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	tags := make([]string, 0)
+	for rows.Next() {
+		var s string
+		if err := rows.Scan(&s); err != nil {
+			return nil, err
+		}
+		tags = append(tags, s)
+	}
+	return tags, rows.Err()
+}
+
+// ListForPoems batch-loads tag slugs for many poems (avoids N+1 on list views).
+func (r *TagRepository) ListForPoems(ctx context.Context, poemIDs []uuid.UUID) (map[uuid.UUID][]string, error) {
+	result := make(map[uuid.UUID][]string)
+	if len(poemIDs) == 0 {
+		return result, nil
+	}
+	rows, err := r.pool.Query(ctx,
+		`SELECT pt.poem_id, t.slug FROM poem_tags pt JOIN tags t ON t.id = pt.tag_id
+		 WHERE pt.poem_id = ANY($1) ORDER BY t.slug`, poemIDs)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var pid uuid.UUID
+		var slug string
+		if err := rows.Scan(&pid, &slug); err != nil {
+			return nil, err
+		}
+		result[pid] = append(result[pid], slug)
+	}
+	return result, rows.Err()
+}

--- a/backend/internal/server/server.go
+++ b/backend/internal/server/server.go
@@ -69,11 +69,12 @@ func (s *Server) setupRoutes() {
 	commentRepo := repository.NewCommentRepository(s.db)
 	followRepo := repository.NewFollowRepository(s.db)
 	notifRepo := repository.NewNotificationRepository(s.db)
+	tagRepo := repository.NewTagRepository(s.db)
 
 	tutorialRepo := repository.NewTutorialRepository(s.db)
 
 	authSvc := service.NewAuthService(userRepo, sessionRepo, magicLinkRepo, webAuthnRepo, s.cfg)
-	poemSvc := service.NewPoemService(poemRepo, stanzaRepo, notifRepo, likeRepo)
+	poemSvc := service.NewPoemService(poemRepo, stanzaRepo, notifRepo, likeRepo, tagRepo)
 	socialSvc := service.NewSocialService(likeRepo, commentRepo, followRepo, notifRepo, poemRepo)
 	tutorialSvc := service.NewTutorialService(tutorialRepo)
 

--- a/backend/internal/service/poem.go
+++ b/backend/internal/service/poem.go
@@ -12,7 +12,7 @@ import (
 type poemStore interface {
 	Create(ctx context.Context, poem *domain.Poem) error
 	GetByID(ctx context.Context, id uuid.UUID) (*domain.Poem, error)
-	List(ctx context.Context, page domain.PaginationParams, format string, sort string) ([]domain.Poem, int, error)
+	List(ctx context.Context, page domain.PaginationParams, format, sort, q, tag string) ([]domain.Poem, int, error)
 	ListByUser(ctx context.Context, userID uuid.UUID, page domain.PaginationParams) ([]domain.Poem, int, error)
 	ListFeed(ctx context.Context, userID uuid.UUID, page domain.PaginationParams) ([]domain.Poem, int, error)
 	ListExplore(ctx context.Context, page domain.PaginationParams) ([]domain.Poem, int, error)
@@ -37,23 +37,49 @@ type likeChecker interface {
 	Exists(ctx context.Context, userID, poemID uuid.UUID) (bool, error)
 }
 
+type tagStore interface {
+	SetForPoem(ctx context.Context, poemID uuid.UUID, names []string) error
+	ListForPoem(ctx context.Context, poemID uuid.UUID) ([]string, error)
+	ListForPoems(ctx context.Context, poemIDs []uuid.UUID) (map[uuid.UUID][]string, error)
+}
+
 type PoemService struct {
 	poems   poemStore
 	stanzas stanzaStore
 	notifs  poemNotifStore
 	likes   likeChecker
+	tags    tagStore
 }
 
-func NewPoemService(poems *repository.PoemRepository, stanzas *repository.StanzaRepository, notifs *repository.NotificationRepository, likes *repository.LikeRepository) *PoemService {
+func NewPoemService(poems *repository.PoemRepository, stanzas *repository.StanzaRepository, notifs *repository.NotificationRepository, likes *repository.LikeRepository, tags *repository.TagRepository) *PoemService {
 	return &PoemService{
 		poems:   poems,
 		stanzas: stanzas,
 		notifs:  notifs,
 		likes:   likes,
+		tags:    tags,
 	}
 }
 
-func (s *PoemService) Create(ctx context.Context, userID uuid.UUID, title, description string, format domain.PoemFormat, approvalMode domain.ApprovalMode, maxStanzas *int) (*domain.Poem, error) {
+// attachTags fills Tags on a batch of poems with one query.
+func (s *PoemService) attachTags(ctx context.Context, poems []domain.Poem) {
+	if s.tags == nil || len(poems) == 0 {
+		return
+	}
+	ids := make([]uuid.UUID, len(poems))
+	for i := range poems {
+		ids[i] = poems[i].ID
+	}
+	byID, err := s.tags.ListForPoems(ctx, ids)
+	if err != nil {
+		return
+	}
+	for i := range poems {
+		poems[i].Tags = byID[poems[i].ID]
+	}
+}
+
+func (s *PoemService) Create(ctx context.Context, userID uuid.UUID, title, description string, format domain.PoemFormat, approvalMode domain.ApprovalMode, maxStanzas *int, tags []string) (*domain.Poem, error) {
 	var poem = &domain.Poem{
 		AuthorID:     userID,
 		Title:        title,
@@ -65,6 +91,13 @@ func (s *PoemService) Create(ctx context.Context, userID uuid.UUID, title, descr
 
 	if err := s.poems.Create(ctx, poem); err != nil {
 		return nil, fmt.Errorf("creating poem: %w", err)
+	}
+
+	if len(tags) > 0 && s.tags != nil {
+		if err := s.tags.SetForPoem(ctx, poem.ID, tags); err != nil {
+			return nil, fmt.Errorf("setting tags: %w", err)
+		}
+		poem.Tags, _ = s.tags.ListForPoem(ctx, poem.ID)
 	}
 
 	return poem, nil
@@ -88,30 +121,54 @@ func (s *PoemService) Get(ctx context.Context, id, viewerID uuid.UUID) (*domain.
 		}
 	}
 
+	if s.tags != nil {
+		poem.Tags, _ = s.tags.ListForPoem(ctx, id)
+	}
+
 	return poem, nil
 }
 
-func (s *PoemService) List(ctx context.Context, page domain.PaginationParams, format, sort string) ([]domain.Poem, int, error) {
-	return s.poems.List(ctx, page, format, sort)
+func (s *PoemService) List(ctx context.Context, page domain.PaginationParams, format, sort, q, tag string) ([]domain.Poem, int, error) {
+	poems, total, err := s.poems.List(ctx, page, format, sort, q, tag)
+	if err != nil {
+		return nil, 0, err
+	}
+	s.attachTags(ctx, poems)
+	return poems, total, nil
 }
 
 func (s *PoemService) ListByUser(ctx context.Context, userID uuid.UUID, page domain.PaginationParams) ([]domain.Poem, int, error) {
-	return s.poems.ListByUser(ctx, userID, page)
+	poems, total, err := s.poems.ListByUser(ctx, userID, page)
+	if err != nil {
+		return nil, 0, err
+	}
+	s.attachTags(ctx, poems)
+	return poems, total, nil
 }
 
 func (s *PoemService) Feed(ctx context.Context, userID uuid.UUID, page domain.PaginationParams) ([]domain.Poem, int, error) {
-	return s.poems.ListFeed(ctx, userID, page)
+	poems, total, err := s.poems.ListFeed(ctx, userID, page)
+	if err != nil {
+		return nil, 0, err
+	}
+	s.attachTags(ctx, poems)
+	return poems, total, nil
 }
 
 func (s *PoemService) Explore(ctx context.Context, page domain.PaginationParams) ([]domain.Poem, int, error) {
-	return s.poems.ListExplore(ctx, page)
+	poems, total, err := s.poems.ListExplore(ctx, page)
+	if err != nil {
+		return nil, 0, err
+	}
+	s.attachTags(ctx, poems)
+	return poems, total, nil
 }
 
 func (s *PoemService) HallOfFame(ctx context.Context, page domain.PaginationParams) ([]domain.Poem, int, error) {
 	return s.poems.ListHallOfFame(ctx, page)
 }
 
-func (s *PoemService) Update(ctx context.Context, userID, poemID uuid.UUID, title, description string) error {
+func (s *PoemService) Update(ctx context.Context, userID, poemID uuid.UUID, title, description string, tags []string) error {
 	poem, err := s.poems.GetByID(ctx, poemID)
 	if err != nil {
 		return fmt.Errorf("poem not found: %w", err)
@@ -122,7 +179,16 @@ func (s *PoemService) Update(ctx context.Context, userID, poemID uuid.UUID, titl
 
 	poem.Title = title
 	poem.Description = description
-	return s.poems.Update(ctx, poem)
+	if err := s.poems.Update(ctx, poem); err != nil {
+		return err
+	}
+
+	if tags != nil && s.tags != nil {
+		if err := s.tags.SetForPoem(ctx, poemID, tags); err != nil {
+			return fmt.Errorf("setting tags: %w", err)
+		}
+	}
+	return nil
 }
 
 func (s *PoemService) Delete(ctx context.Context, userID, poemID uuid.UUID) error {

--- a/backend/internal/service/poem_test.go
+++ b/backend/internal/service/poem_test.go
@@ -24,8 +24,8 @@ func (m *mockPoemStore) GetByID(ctx context.Context, id uuid.UUID) (*domain.Poem
 	p, _ := args.Get(0).(*domain.Poem)
 	return p, args.Error(1)
 }
-func (m *mockPoemStore) List(ctx context.Context, page domain.PaginationParams, format, sort string) ([]domain.Poem, int, error) {
-	args := m.Called(ctx, page, format, sort)
+func (m *mockPoemStore) List(ctx context.Context, page domain.PaginationParams, format, sort, q, tag string) ([]domain.Poem, int, error) {
+	args := m.Called(ctx, page, format, sort, q, tag)
 	poems, _ := args.Get(0).([]domain.Poem)
 	return poems, args.Int(1), args.Error(2)
 }
@@ -87,8 +87,42 @@ func (m *mockPoemNotifStore) Create(ctx context.Context, notif *domain.Notificat
 	return m.Called(ctx, notif).Error(0)
 }
 
+// mockTagStore
+
+type mockTagStore struct{ mock.Mock }
+
+func (m *mockTagStore) SetForPoem(ctx context.Context, poemID uuid.UUID, names []string) error {
+	return m.Called(ctx, poemID, names).Error(0)
+}
+func (m *mockTagStore) ListForPoem(ctx context.Context, poemID uuid.UUID) ([]string, error) {
+	args := m.Called(ctx, poemID)
+	tags, _ := args.Get(0).([]string)
+	return tags, args.Error(1)
+}
+func (m *mockTagStore) ListForPoems(ctx context.Context, poemIDs []uuid.UUID) (map[uuid.UUID][]string, error) {
+	args := m.Called(ctx, poemIDs)
+	tags, _ := args.Get(0).(map[uuid.UUID][]string)
+	return tags, args.Error(1)
+}
+
 func newPoemSvc(poems *mockPoemStore, stanzas *mockStanzaStore, notifs *mockPoemNotifStore) *PoemService {
 	return &PoemService{poems: poems, stanzas: stanzas, notifs: notifs}
+}
+
+func TestPoemService_Create_WithTags(t *testing.T) {
+	poems := &mockPoemStore{}
+	tags := &mockTagStore{}
+	svc := newPoemSvc(poems, &mockStanzaStore{}, &mockPoemNotifStore{})
+	svc.tags = tags
+
+	poems.On("Create", mock.Anything, mock.AnythingOfType("*domain.Poem")).Return(nil)
+	tags.On("SetForPoem", mock.Anything, mock.Anything, []string{"nature", "haiku"}).Return(nil)
+	tags.On("ListForPoem", mock.Anything, mock.Anything).Return([]string{"haiku", "nature"}, nil)
+
+	poem, err := svc.Create(context.Background(), uuid.New(), "T", "", domain.FormatHaiku, domain.ApprovalOpen, nil, []string{"nature", "haiku"})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"haiku", "nature"}, poem.Tags)
+	tags.AssertCalled(t, "SetForPoem", mock.Anything, mock.Anything, []string{"nature", "haiku"})
 }
 
 // Create tests
@@ -102,7 +136,7 @@ func TestPoemService_Create_Success(t *testing.T) {
 	userID := uuid.New()
 	poems.On("Create", mock.Anything, mock.AnythingOfType("*domain.Poem")).Return(nil)
 
-	poem, err := svc.Create(context.Background(), userID, "Test Poem", "a poem", domain.FormatFreeVerse, domain.ApprovalOpen, nil)
+	poem, err := svc.Create(context.Background(), userID, "Test Poem", "a poem", domain.FormatFreeVerse, domain.ApprovalOpen, nil, nil)
 	require.NoError(t, err)
 	assert.Equal(t, "Test Poem", poem.Title)
 	assert.Equal(t, userID, poem.AuthorID)
@@ -115,7 +149,7 @@ func TestPoemService_Create_StoreError(t *testing.T) {
 
 	poems.On("Create", mock.Anything, mock.Anything).Return(errors.New("db error"))
 
-	_, err := svc.Create(context.Background(), uuid.New(), "Title", "", domain.FormatHaiku, domain.ApprovalOpen, nil)
+	_, err := svc.Create(context.Background(), uuid.New(), "Title", "", domain.FormatHaiku, domain.ApprovalOpen, nil, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "creating poem")
 }

--- a/backend/migrations/000002_tags.down.sql
+++ b/backend/migrations/000002_tags.down.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS poem_tags;
+DROP TABLE IF EXISTS tags;

--- a/backend/migrations/000002_tags.up.sql
+++ b/backend/migrations/000002_tags.up.sql
@@ -1,0 +1,14 @@
+CREATE TABLE tags (
+    id         UUID        PRIMARY KEY,
+    name       TEXT        NOT NULL,
+    slug       TEXT        NOT NULL UNIQUE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE poem_tags (
+    poem_id UUID NOT NULL REFERENCES poems(id) ON DELETE CASCADE,
+    tag_id  UUID NOT NULL REFERENCES tags(id) ON DELETE CASCADE,
+    PRIMARY KEY (poem_id, tag_id)
+);
+
+CREATE INDEX idx_poem_tags_tag_id ON poem_tags (tag_id);


### PR DESCRIPTION
Backend half of #74, verified green (go build/vet/test).

- Migration `000002_tags`: `tags` + `poem_tags`.
- Poems take up to 10 tags on create/edit; tags come back on the poem detail and on list items (batch-loaded to avoid N+1).
- `GET /poems` now accepts `q` (searches title/description/author display name) and `tag` (slug) filters.
- Tag slugs are normalised; setting tags replaces the set in one transaction.

Additive only, so it merges safely ahead of the UI. Frontend (search bar, tag chips, tag input in the editor) comes next, also under #74.

Addresses #74.