### PR TITLE
Poem search and tags (frontend)

### DIFF
--- a/frontend/src/components/poem/PoemCard.tsx
+++ b/frontend/src/components/poem/PoemCard.tsx
@@ -52,6 +52,21 @@ export function PoemCard({ poem }: PoemCardProps) {
         </div>
       )}
 
+      {poem.tags && poem.tags.length > 0 && (
+        <div className="mb-4 flex flex-wrap gap-1.5">
+          {poem.tags.map((tag) => (
+            <Link
+              key={tag}
+              to={`/explore?tag=${encodeURIComponent(tag)}`}
+              onClick={(e) => e.stopPropagation()}
+              className="rounded-full bg-parchment-dark px-2 py-0.5 font-sans text-xs text-feather no-underline hover:text-accent"
+            >
+              #{tag}
+            </Link>
+          ))}
+        </div>
+      )}
+
       <div className="flex items-center gap-4 font-sans text-sm text-feather">
         <span className="flex items-center gap-1">
           <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>

--- a/frontend/src/components/poem/PoemDetail.tsx
+++ b/frontend/src/components/poem/PoemDetail.tsx
@@ -66,6 +66,20 @@ export function PoemDetail({ poem }: PoemDetailProps) {
         {poem.description && (
           <p className="text-base leading-relaxed text-feather">{poem.description}</p>
         )}
+
+        {poem.tags && poem.tags.length > 0 && (
+          <div className="mt-3 flex flex-wrap gap-1.5">
+            {poem.tags.map((t) => (
+              <Link
+                key={t}
+                to={`/explore?tag=${encodeURIComponent(t)}`}
+                className="rounded-full bg-parchment-dark px-2.5 py-0.5 font-sans text-xs text-feather no-underline hover:text-accent"
+              >
+                #{t}
+              </Link>
+            ))}
+          </div>
+        )}
       </header>
 
       {isAuthor && (

--- a/frontend/src/components/poem/PoemEditor.tsx
+++ b/frontend/src/components/poem/PoemEditor.tsx
@@ -30,6 +30,7 @@ export function PoemEditor() {
   var [format, setFormat] = useState<PoemFormat>('free_verse');
   var [approvalMode, setApprovalMode] = useState<ApprovalMode>('open');
   var [maxStanzas, setMaxStanzas] = useState('');
+  var [tags, setTags] = useState('');
   var [error, setError] = useState('');
 
   async function handleSubmit(e: React.FormEvent) {
@@ -41,6 +42,12 @@ export function PoemEditor() {
       return;
     }
 
+    var parsedTags = tags
+      .split(',')
+      .map((t) => t.trim())
+      .filter(Boolean)
+      .slice(0, 10);
+
     try {
       var poem = await mutation.mutateAsync({
         title: title.trim(),
@@ -49,6 +56,7 @@ export function PoemEditor() {
         format,
         approvalMode,
         maxStanzas: maxStanzas ? Number(maxStanzas) : undefined,
+        tags: parsedTags.length ? parsedTags : undefined,
       });
       navigate(`/poems/${poem.id}`);
     } catch (err) {
@@ -154,6 +162,20 @@ export function PoemEditor() {
                 </label>
               ))}
             </div>
+          </div>
+
+          <div>
+            <label htmlFor="tags" className="mb-1 block font-sans text-sm font-medium text-ink">
+              Tags <span className="font-normal text-feather">(optional, comma-separated)</span>
+            </label>
+            <input
+              id="tags"
+              type="text"
+              value={tags}
+              onChange={(e) => setTags(e.target.value)}
+              placeholder="nature, love, autumn"
+              className="w-full rounded-lg border border-parchment-dark bg-white px-4 py-2 font-sans text-sm text-ink outline-none transition-colors focus:border-accent"
+            />
           </div>
 
           <div>

--- a/frontend/src/hooks/usePoems.ts
+++ b/frontend/src/hooks/usePoems.ts
@@ -3,12 +3,14 @@ import { api } from '@/lib/api';
 import type { Poem, CreatePoemInput, SubmitStanzaInput, Stanza } from '@/types/poem';
 import type { PaginatedResponse, PaginationParams } from '@/types/api';
 
-export function usePoems(params?: PaginationParams & { format?: string; sort?: string }) {
+export function usePoems(params?: PaginationParams & { format?: string; sort?: string; q?: string; tag?: string }) {
   var query = new URLSearchParams();
   if (params?.page) { query.set('page', String(params.page)); }
   if (params?.pageSize) { query.set('pageSize', String(params.pageSize)); }
   if (params?.format) { query.set('format', params.format); }
   if (params?.sort) { query.set('sort', params.sort); }
+  if (params?.q) { query.set('q', params.q); }
+  if (params?.tag) { query.set('tag', params.tag); }
 
   return useQuery({
     queryKey: ['poems', params],

--- a/frontend/src/pages/ExplorePage.tsx
+++ b/frontend/src/pages/ExplorePage.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { motion } from 'framer-motion';
 import { usePoems } from '@/hooks/usePoems';
 import { PoemCard } from '@/components/poem/PoemCard';
@@ -18,22 +19,71 @@ var formats: (PoemFormat | 'all')[] = [
 type SortOption = 'recent' | 'popular';
 
 export function ExplorePage() {
+  var [searchParams, setSearchParams] = useSearchParams();
+  var q = searchParams.get('q') ?? '';
+  var tag = searchParams.get('tag') ?? '';
+
   var [page, setPage] = useState(1);
   var [format, setFormat] = useState<PoemFormat | 'all'>('all');
   var [sort, setSort] = useState<SortOption>('recent');
+  var [input, setInput] = useState(q);
 
   var { data, isLoading } = usePoems({
     page,
     pageSize: 12,
     format: format === 'all' ? undefined : format,
     sort,
+    q: q || undefined,
+    tag: tag || undefined,
   });
+
+  function submitSearch(e: React.FormEvent) {
+    e.preventDefault();
+    var next = new URLSearchParams(searchParams);
+    if (input.trim()) {
+      next.set('q', input.trim());
+    } else {
+      next.delete('q');
+    }
+    setSearchParams(next);
+    setPage(1);
+  }
+
+  function clearTag() {
+    var next = new URLSearchParams(searchParams);
+    next.delete('tag');
+    setSearchParams(next);
+    setPage(1);
+  }
 
   var totalPages = data ? Math.ceil(data.totalCount / data.pageSize) : 0;
 
   return (
     <div>
       <h1 className="mb-6 font-serif text-3xl font-bold text-ink">Explore</h1>
+
+      <form onSubmit={submitSearch} className="mb-6 flex gap-2">
+        <input
+          type="text"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          placeholder="Search poems by title, description or author..."
+          className="w-full rounded-lg border border-parchment-dark bg-white px-4 py-2 font-sans text-sm text-ink outline-none transition-colors focus:border-accent"
+        />
+        <button type="submit" className="btn-primary">Search</button>
+      </form>
+
+      {tag && (
+        <div className="mb-6 flex items-center gap-2 font-sans text-sm text-feather">
+          <span>Filtered by tag:</span>
+          <button
+            onClick={clearTag}
+            className="flex items-center gap-1 rounded-full bg-accent px-3 py-1 text-white"
+          >
+            #{tag} <span aria-hidden>✕</span>
+          </button>
+        </div>
+      )}
 
       <div className="mb-6 flex flex-wrap gap-2">
         {formats.map((f) => (

--- a/frontend/src/types/poem.ts
+++ b/frontend/src/types/poem.ts
@@ -28,6 +28,7 @@ export interface Poem {
   stanzaCount: number;
   commentCount: number;
   likedByMe?: boolean;
+  tags?: string[];
   stanzas?: Stanza[];
   createdAt: string;
   updatedAt: string;
@@ -52,6 +53,7 @@ export interface CreatePoemInput {
   format: PoemFormat;
   approvalMode: ApprovalMode;
   maxStanzas?: number;
+  tags?: string[];
 }
 
 export interface SubmitStanzaInput {


### PR DESCRIPTION
Frontend half of #74, verified green (build + 55 tests). Consumes the API from PR #78.

- Explore has a search box (`q`) and a tag filter driven by the URL (`?tag=slug`), so tag chips are shareable deep links.
- Poem cards and the detail view render tag chips that filter explore on click.
- The poem editor takes a comma-separated tags field (capped at 10).

Closes #74.