### PR TITLE
Per-stanza likes (backend)

### DIFF
--- a/backend/internal/domain/poem.go
+++ b/backend/internal/domain/poem.go
@@ -64,5 +64,7 @@ type Stanza struct {
 	Position       int          `json:"position"`
 	LiteraryDevice string       `json:"literaryDevice,omitempty"`
 	Status         StanzaStatus `json:"status"`
+	LikeCount      int          `json:"likeCount"`
+	LikedByMe      bool         `json:"likedByMe"`
 	CreatedAt      time.Time    `json:"createdAt"`
 }

--- a/backend/internal/handler/social.go
+++ b/backend/internal/handler/social.go
@@ -14,6 +14,7 @@ import (
 
 type socialService interface {
 	ToggleLike(ctx context.Context, userID, poemID uuid.UUID) (bool, error)
+	ToggleStanzaLike(ctx context.Context, userID, stanzaID uuid.UUID) (bool, error)
 	AddComment(ctx context.Context, userID, poemID uuid.UUID, parentID *uuid.UUID, text string) (*domain.Comment, error)
 	DeleteComment(ctx context.Context, userID, commentID uuid.UUID) error
 	ListComments(ctx context.Context, poemID uuid.UUID, page domain.PaginationParams) ([]domain.Comment, int, error)
@@ -46,6 +47,28 @@ func (h *SocialHandler) ToggleLike(w http.ResponseWriter, r *http.Request) {
 	}
 
 	liked, err := h.svc.ToggleLike(r.Context(), userID, poemID)
+	if err != nil {
+		respondError(w, http.StatusInternalServerError, "failed to toggle like")
+		return
+	}
+
+	respondJSON(w, http.StatusOK, map[string]bool{"liked": liked})
+}
+
+func (h *SocialHandler) ToggleStanzaLike(w http.ResponseWriter, r *http.Request) {
+	userID, ok := middleware.UserIDFromContext(r.Context())
+	if !ok {
+		respondError(w, http.StatusUnauthorized, "unauthorized")
+		return
+	}
+
+	stanzaID, err := uuid.Parse(chi.URLParam(r, "stanzaID"))
+	if err != nil {
+		respondError(w, http.StatusBadRequest, "invalid stanza ID")
+		return
+	}
+
+	liked, err := h.svc.ToggleStanzaLike(r.Context(), userID, stanzaID)
 	if err != nil {
 		respondError(w, http.StatusInternalServerError, "failed to toggle like")
 		return

--- a/backend/internal/handler/social_test.go
+++ b/backend/internal/handler/social_test.go
@@ -23,6 +23,10 @@ func (m *mockSocialService) ToggleLike(ctx context.Context, userID, poemID uuid.
 	args := m.Called(ctx, userID, poemID)
 	return args.Bool(0), args.Error(1)
 }
+func (m *mockSocialService) ToggleStanzaLike(ctx context.Context, userID, stanzaID uuid.UUID) (bool, error) {
+	args := m.Called(ctx, userID, stanzaID)
+	return args.Bool(0), args.Error(1)
+}
 func (m *mockSocialService) AddComment(ctx context.Context, userID, poemID uuid.UUID, parentID *uuid.UUID, text string) (*domain.Comment, error) {
 	args := m.Called(ctx, userID, poemID, parentID, text)
 	c, _ := args.Get(0).(*domain.Comment)

--- a/backend/internal/repository/stanza.go
+++ b/backend/internal/repository/stanza.go
@@ -34,7 +34,7 @@ func (r *StanzaRepository) Create(ctx context.Context, stanza *domain.Stanza) er
 
 func (r *StanzaRepository) ListByPoem(ctx context.Context, poemID uuid.UUID) ([]domain.Stanza, error) {
 	rows, err := r.pool.Query(ctx,
-		`SELECT s.id, s.poem_id, s.author_id, s.text, s.position, s.literary_device, s.status, s.created_at,
+		`SELECT s.id, s.poem_id, s.author_id, s.text, s.position, s.literary_device, s.status, s.like_count, s.created_at,
 		        u.id, u.display_name, u.email, u.bio, u.avatar_url, u.is_verified, u.created_at, u.updated_at
 		 FROM stanzas s JOIN users u ON u.id = s.author_id
 		 WHERE s.poem_id = $1 ORDER BY s.position ASC`, poemID,
@@ -49,7 +49,7 @@ func (r *StanzaRepository) ListByPoem(ctx context.Context, poemID uuid.UUID) ([]
 		var s domain.Stanza
 		var author domain.User
 		err := rows.Scan(
-			&s.ID, &s.PoemID, &s.AuthorID, &s.Text, &s.Position, &s.LiteraryDevice, &s.Status, &s.CreatedAt,
+			&s.ID, &s.PoemID, &s.AuthorID, &s.Text, &s.Position, &s.LiteraryDevice, &s.Status, &s.LikeCount, &s.CreatedAt,
 			&author.ID, &author.DisplayName, &author.Email, &author.Bio, &author.AvatarURL,
 			&author.IsVerified, &author.CreatedAt, &author.UpdatedAt,
 		)

--- a/backend/internal/repository/stanzalike.go
+++ b/backend/internal/repository/stanzalike.go
@@ -1,0 +1,77 @@
+package repository
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+type StanzaLikeRepository struct {
+	pool *pgxpool.Pool
+}
+
+func NewStanzaLikeRepository(pool *pgxpool.Pool) *StanzaLikeRepository {
+	return &StanzaLikeRepository{pool: pool}
+}
+
+// ToggleLike flips the like and adjusts stanzas.like_count in one transaction.
+// Returns the resulting liked state.
+func (r *StanzaLikeRepository) ToggleLike(ctx context.Context, userID, stanzaID uuid.UUID) (bool, error) {
+	tx, err := r.pool.Begin(ctx)
+	if err != nil {
+		return false, err
+	}
+	defer tx.Rollback(ctx)
+
+	del, err := tx.Exec(ctx, `DELETE FROM stanza_likes WHERE user_id = $1 AND stanza_id = $2`, userID, stanzaID)
+	if err != nil {
+		return false, err
+	}
+	if del.RowsAffected() > 0 {
+		if _, err := tx.Exec(ctx, `UPDATE stanzas SET like_count = like_count - 1 WHERE id = $1`, stanzaID); err != nil {
+			return false, err
+		}
+		return false, tx.Commit(ctx)
+	}
+
+	ins, err := tx.Exec(ctx,
+		`INSERT INTO stanza_likes (user_id, stanza_id, created_at) VALUES ($1, $2, now())
+		 ON CONFLICT (user_id, stanza_id) DO NOTHING`,
+		userID, stanzaID,
+	)
+	if err != nil {
+		return false, err
+	}
+	if ins.RowsAffected() > 0 {
+		if _, err := tx.Exec(ctx, `UPDATE stanzas SET like_count = like_count + 1 WHERE id = $1`, stanzaID); err != nil {
+			return false, err
+		}
+	}
+	return true, tx.Commit(ctx)
+}
+
+// LikedStanzaIDs returns which of the given stanzas the user has liked.
+func (r *StanzaLikeRepository) LikedStanzaIDs(ctx context.Context, userID uuid.UUID, stanzaIDs []uuid.UUID) (map[uuid.UUID]bool, error) {
+	liked := make(map[uuid.UUID]bool)
+	if userID == uuid.Nil || len(stanzaIDs) == 0 {
+		return liked, nil
+	}
+	rows, err := r.pool.Query(ctx,
+		`SELECT stanza_id FROM stanza_likes WHERE user_id = $1 AND stanza_id = ANY($2)`,
+		userID, stanzaIDs,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var id uuid.UUID
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		liked[id] = true
+	}
+	return liked, rows.Err()
+}

--- a/backend/internal/server/server.go
+++ b/backend/internal/server/server.go
@@ -66,6 +66,7 @@ func (s *Server) setupRoutes() {
 	poemRepo := repository.NewPoemRepository(s.db)
 	stanzaRepo := repository.NewStanzaRepository(s.db)
 	likeRepo := repository.NewLikeRepository(s.db)
+	stanzaLikeRepo := repository.NewStanzaLikeRepository(s.db)
 	commentRepo := repository.NewCommentRepository(s.db)
 	followRepo := repository.NewFollowRepository(s.db)
 	notifRepo := repository.NewNotificationRepository(s.db)
@@ -74,8 +75,8 @@ func (s *Server) setupRoutes() {
 	tutorialRepo := repository.NewTutorialRepository(s.db)
 
 	authSvc := service.NewAuthService(userRepo, sessionRepo, magicLinkRepo, webAuthnRepo, s.cfg)
-	poemSvc := service.NewPoemService(poemRepo, stanzaRepo, notifRepo, likeRepo, tagRepo)
-	socialSvc := service.NewSocialService(likeRepo, commentRepo, followRepo, notifRepo, poemRepo)
+	poemSvc := service.NewPoemService(poemRepo, stanzaRepo, notifRepo, likeRepo, tagRepo, stanzaLikeRepo)
+	socialSvc := service.NewSocialService(likeRepo, stanzaLikeRepo, commentRepo, followRepo, notifRepo, poemRepo)
 	tutorialSvc := service.NewTutorialService(tutorialRepo)
 
 	authHandler := handler.NewAuthHandler(authSvc)
@@ -117,6 +118,7 @@ func (s *Server) setupRoutes() {
 				r.Get("/stanzas", poemHandler.ListStanzas)
 				r.With(authMiddleware).Post("/stanzas", poemHandler.SubmitStanza)
 				r.With(authMiddleware).Put("/stanzas/{stanzaID}", poemHandler.ReviewStanza)
+				r.With(authMiddleware).Post("/stanzas/{stanzaID}/like", socialHandler.ToggleStanzaLike)
 
 				// Social on poems
 				r.With(authMiddleware).Post("/like", socialHandler.ToggleLike)

--- a/backend/internal/service/poem.go
+++ b/backend/internal/service/poem.go
@@ -43,21 +43,27 @@ type tagStore interface {
 	ListForPoems(ctx context.Context, poemIDs []uuid.UUID) (map[uuid.UUID][]string, error)
 }
 
-type PoemService struct {
-	poems   poemStore
-	stanzas stanzaStore
-	notifs  poemNotifStore
-	likes   likeChecker
-	tags    tagStore
+type stanzaLikeChecker interface {
+	LikedStanzaIDs(ctx context.Context, userID uuid.UUID, stanzaIDs []uuid.UUID) (map[uuid.UUID]bool, error)
 }
 
-func NewPoemService(poems *repository.PoemRepository, stanzas *repository.StanzaRepository, notifs *repository.NotificationRepository, likes *repository.LikeRepository, tags *repository.TagRepository) *PoemService {
+type PoemService struct {
+	poems       poemStore
+	stanzas     stanzaStore
+	notifs      poemNotifStore
+	likes       likeChecker
+	tags        tagStore
+	stanzaLikes stanzaLikeChecker
+}
+
+func NewPoemService(poems *repository.PoemRepository, stanzas *repository.StanzaRepository, notifs *repository.NotificationRepository, likes *repository.LikeRepository, tags *repository.TagRepository, stanzaLikes *repository.StanzaLikeRepository) *PoemService {
 	return &PoemService{
-		poems:   poems,
-		stanzas: stanzas,
-		notifs:  notifs,
-		likes:   likes,
-		tags:    tags,
+		poems:       poems,
+		stanzas:     stanzas,
+		notifs:      notifs,
+		likes:       likes,
+		tags:        tags,
+		stanzaLikes: stanzaLikes,
 	}
 }
 
@@ -118,6 +124,18 @@ func (s *PoemService) Get(ctx context.Context, id, viewerID uuid.UUID) (*domain.
 	if viewerID != uuid.Nil && s.likes != nil {
 		if liked, err := s.likes.Exists(ctx, viewerID, id); err == nil {
 			poem.LikedByMe = liked
+		}
+	}
+
+	if viewerID != uuid.Nil && s.stanzaLikes != nil && len(poem.Stanzas) > 0 {
+		ids := make([]uuid.UUID, len(poem.Stanzas))
+		for i := range poem.Stanzas {
+			ids[i] = poem.Stanzas[i].ID
+		}
+		if liked, err := s.stanzaLikes.LikedStanzaIDs(ctx, viewerID, ids); err == nil {
+			for i := range poem.Stanzas {
+				poem.Stanzas[i].LikedByMe = liked[poem.Stanzas[i].ID]
+			}
 		}
 	}
 

--- a/backend/internal/service/social.go
+++ b/backend/internal/service/social.go
@@ -14,6 +14,10 @@ type likeStore interface {
 	Exists(ctx context.Context, userID, poemID uuid.UUID) (bool, error)
 }
 
+type stanzaLikeStore interface {
+	ToggleLike(ctx context.Context, userID, stanzaID uuid.UUID) (bool, error)
+}
+
 type commentStore interface {
 	Create(ctx context.Context, comment *domain.Comment) error
 	GetByID(ctx context.Context, id uuid.UUID) (*domain.Comment, error)
@@ -41,27 +45,38 @@ type socialPoemStore interface {
 }
 
 type SocialService struct {
-	likes    likeStore
-	comments commentStore
-	follows  followStore
-	notifs   socialNotifStore
-	poems    socialPoemStore
+	likes       likeStore
+	stanzaLikes stanzaLikeStore
+	comments    commentStore
+	follows     followStore
+	notifs      socialNotifStore
+	poems       socialPoemStore
 }
 
 func NewSocialService(
 	likes *repository.LikeRepository,
+	stanzaLikes *repository.StanzaLikeRepository,
 	comments *repository.CommentRepository,
 	follows *repository.FollowRepository,
 	notifs *repository.NotificationRepository,
 	poems *repository.PoemRepository,
 ) *SocialService {
 	return &SocialService{
-		likes:    likes,
-		comments: comments,
-		follows:  follows,
-		notifs:   notifs,
-		poems:    poems,
+		likes:       likes,
+		stanzaLikes: stanzaLikes,
+		comments:    comments,
+		follows:     follows,
+		notifs:      notifs,
+		poems:       poems,
 	}
+}
+
+func (s *SocialService) ToggleStanzaLike(ctx context.Context, userID, stanzaID uuid.UUID) (bool, error) {
+	liked, err := s.stanzaLikes.ToggleLike(ctx, userID, stanzaID)
+	if err != nil {
+		return false, fmt.Errorf("toggling stanza like: %w", err)
+	}
+	return liked, nil
 }
 
 func (s *SocialService) ToggleLike(ctx context.Context, userID, poemID uuid.UUID) (bool, error) {

--- a/backend/internal/service/social_test.go
+++ b/backend/internal/service/social_test.go
@@ -100,6 +100,13 @@ func (m *mockSocialPoemStore) IncrementCounter(ctx context.Context, id uuid.UUID
 	return m.Called(ctx, id, column, delta).Error(0)
 }
 
+type mockStanzaLikeStore struct{ mock.Mock }
+
+func (m *mockStanzaLikeStore) ToggleLike(ctx context.Context, userID, stanzaID uuid.UUID) (bool, error) {
+	args := m.Called(ctx, userID, stanzaID)
+	return args.Bool(0), args.Error(1)
+}
+
 func newSocialSvc(likes *mockLikeStore, comments *mockCommentStore, follows *mockFollowStore, notifs *mockSocialNotifStore, poems *mockSocialPoemStore) *SocialService {
 	return &SocialService{
 		likes:    likes,
@@ -146,6 +153,20 @@ func TestSocialService_ToggleLike_Unlike(t *testing.T) {
 	liked, err := svc.ToggleLike(context.Background(), userID, poemID)
 	require.NoError(t, err)
 	assert.False(t, liked)
+}
+
+func TestSocialService_ToggleStanzaLike(t *testing.T) {
+	stanzaLikes := &mockStanzaLikeStore{}
+	svc := newSocialSvc(&mockLikeStore{}, &mockCommentStore{}, &mockFollowStore{}, &mockSocialNotifStore{}, &mockSocialPoemStore{})
+	svc.stanzaLikes = stanzaLikes
+
+	userID := uuid.New()
+	stanzaID := uuid.New()
+	stanzaLikes.On("ToggleLike", mock.Anything, userID, stanzaID).Return(true, nil)
+
+	liked, err := svc.ToggleStanzaLike(context.Background(), userID, stanzaID)
+	require.NoError(t, err)
+	assert.True(t, liked)
 }
 
 // AddComment tests

--- a/backend/migrations/000003_stanza_likes.down.sql
+++ b/backend/migrations/000003_stanza_likes.down.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS stanza_likes;
+ALTER TABLE stanzas DROP COLUMN IF EXISTS like_count;

--- a/backend/migrations/000003_stanza_likes.up.sql
+++ b/backend/migrations/000003_stanza_likes.up.sql
@@ -1,0 +1,10 @@
+ALTER TABLE stanzas ADD COLUMN like_count INT NOT NULL DEFAULT 0;
+
+CREATE TABLE stanza_likes (
+    user_id    UUID        NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    stanza_id  UUID        NOT NULL REFERENCES stanzas(id) ON DELETE CASCADE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (user_id, stanza_id)
+);
+
+CREATE INDEX idx_stanza_likes_stanza_id ON stanza_likes (stanza_id);


### PR DESCRIPTION
Backend half of #75, verified green (go build/vet/test).

- Migration `000003_stanza_likes`: `stanza_likes` table + a `like_count` column on stanzas.
- `POST /poems/{poemID}/stanzas/{stanzaID}/like` toggles a stanza like atomically (delete-or-insert-on-conflict + counter in one tx, same shape as the poem like).
- Stanzas carry `likeCount` always, and the poem detail sets `likedByMe` per stanza for the current viewer (one batch query).

Additive, merges ahead of the UI. Frontend (like control on each stanza) next, also under #75.

Addresses #75.