### PR TITLE
Poem drafts (backend)

### DIFF
--- a/backend/internal/domain/poem.go
+++ b/backend/internal/domain/poem.go
@@ -37,6 +37,7 @@ type Poem struct {
 	ApprovalMode    ApprovalMode `json:"approvalMode"`
 	MaxStanzas      *int         `json:"maxStanzas"`
 	IsHallOfFame    bool         `json:"isHallOfFame"`
+	Published       bool         `json:"published"`
 	LikeCount       int          `json:"likeCount"`
 	StanzaCount     int          `json:"stanzaCount"`
 	CommentCount    int          `json:"commentCount"`

--- a/backend/internal/handler/poem.go
+++ b/backend/internal/handler/poem.go
@@ -14,8 +14,10 @@ import (
 )
 
 type poemService interface {
-	Create(ctx context.Context, userID uuid.UUID, title, description string, format domain.PoemFormat, approvalMode domain.ApprovalMode, maxStanzas *int, tags []string) (*domain.Poem, error)
+	Create(ctx context.Context, userID uuid.UUID, title, description string, format domain.PoemFormat, approvalMode domain.ApprovalMode, maxStanzas *int, tags []string, published bool) (*domain.Poem, error)
 	Get(ctx context.Context, id, viewerID uuid.UUID) (*domain.Poem, error)
+	Drafts(ctx context.Context, userID uuid.UUID, page domain.PaginationParams) ([]domain.Poem, int, error)
+	Publish(ctx context.Context, userID, poemID uuid.UUID) error
 	List(ctx context.Context, page domain.PaginationParams, format, sort, q, tag string) ([]domain.Poem, int, error)
 	ListByUser(ctx context.Context, userID uuid.UUID, page domain.PaginationParams) ([]domain.Poem, int, error)
 	Update(ctx context.Context, userID, poemID uuid.UUID, title, description string, tags []string) error
@@ -50,6 +52,7 @@ func (h *PoemHandler) Create(w http.ResponseWriter, r *http.Request) {
 		ApprovalMode domain.ApprovalMode `json:"approvalMode"`
 		MaxStanzas   *int               `json:"maxStanzas"`
 		Tags         []string           `json:"tags"`
+		Draft        bool               `json:"draft"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		respondError(w, http.StatusBadRequest, "invalid request body")
@@ -76,7 +79,7 @@ func (h *PoemHandler) Create(w http.ResponseWriter, r *http.Request) {
 		body.ApprovalMode = domain.ApprovalOpen
 	}
 
-	poem, err := h.svc.Create(r.Context(), userID, body.Title, body.Description, body.Format, body.ApprovalMode, body.MaxStanzas, body.Tags)
+	poem, err := h.svc.Create(r.Context(), userID, body.Title, body.Description, body.Format, body.ApprovalMode, body.MaxStanzas, body.Tags, !body.Draft)
 	if err != nil {
 		respondError(w, http.StatusInternalServerError, "failed to create poem")
 		return
@@ -100,6 +103,53 @@ func (h *PoemHandler) Get(w http.ResponseWriter, r *http.Request) {
 	}
 
 	respondJSON(w, http.StatusOK, poem)
+}
+
+func (h *PoemHandler) Drafts(w http.ResponseWriter, r *http.Request) {
+	userID, ok := middleware.UserIDFromContext(r.Context())
+	if !ok {
+		respondError(w, http.StatusUnauthorized, "unauthorized")
+		return
+	}
+
+	var page = parsePagination(r)
+	poems, total, err := h.svc.Drafts(r.Context(), userID, page)
+	if err != nil {
+		respondError(w, http.StatusInternalServerError, "failed to list drafts")
+		return
+	}
+
+	respondJSON(w, http.StatusOK, domain.PaginatedResult[domain.Poem]{
+		Items:      poems,
+		TotalCount: total,
+		Page:       page.Page,
+		PageSize:   page.PageSize,
+	})
+}
+
+func (h *PoemHandler) Publish(w http.ResponseWriter, r *http.Request) {
+	userID, ok := middleware.UserIDFromContext(r.Context())
+	if !ok {
+		respondError(w, http.StatusUnauthorized, "unauthorized")
+		return
+	}
+
+	poemID, err := uuid.Parse(chi.URLParam(r, "poemID"))
+	if err != nil {
+		respondError(w, http.StatusBadRequest, "invalid poem ID")
+		return
+	}
+
+	if err := h.svc.Publish(r.Context(), userID, poemID); err != nil {
+		if err.Error() == "not the poem author" {
+			respondError(w, http.StatusForbidden, "you are not the author of this poem")
+			return
+		}
+		respondError(w, http.StatusInternalServerError, "failed to publish poem")
+		return
+	}
+
+	respondJSON(w, http.StatusOK, map[string]string{"message": "poem published"})
 }
 
 func (h *PoemHandler) List(w http.ResponseWriter, r *http.Request) {

--- a/backend/internal/handler/poem_test.go
+++ b/backend/internal/handler/poem_test.go
@@ -20,10 +20,18 @@ import (
 
 type mockPoemService struct{ mock.Mock }
 
-func (m *mockPoemService) Create(ctx context.Context, userID uuid.UUID, title, description string, format domain.PoemFormat, approvalMode domain.ApprovalMode, maxStanzas *int, tags []string) (*domain.Poem, error) {
-	args := m.Called(ctx, userID, title, description, format, approvalMode, maxStanzas, tags)
+func (m *mockPoemService) Create(ctx context.Context, userID uuid.UUID, title, description string, format domain.PoemFormat, approvalMode domain.ApprovalMode, maxStanzas *int, tags []string, published bool) (*domain.Poem, error) {
+	args := m.Called(ctx, userID, title, description, format, approvalMode, maxStanzas, tags, published)
 	p, _ := args.Get(0).(*domain.Poem)
 	return p, args.Error(1)
+}
+func (m *mockPoemService) Drafts(ctx context.Context, userID uuid.UUID, page domain.PaginationParams) ([]domain.Poem, int, error) {
+	args := m.Called(ctx, userID, page)
+	poems, _ := args.Get(0).([]domain.Poem)
+	return poems, args.Int(1), args.Error(2)
+}
+func (m *mockPoemService) Publish(ctx context.Context, userID, poemID uuid.UUID) error {
+	return m.Called(ctx, userID, poemID).Error(0)
 }
 func (m *mockPoemService) Get(ctx context.Context, id, viewerID uuid.UUID) (*domain.Poem, error) {
 	args := m.Called(ctx, id, viewerID)
@@ -87,7 +95,7 @@ func TestPoemHandler_Create_ValidBody(t *testing.T) {
 
 	userID := uuid.New()
 	poem := &domain.Poem{ID: uuid.New(), Title: "My Poem", Format: domain.FormatFreeVerse}
-	svc.On("Create", mock.Anything, userID, "My Poem", "", domain.FormatFreeVerse, domain.ApprovalOpen, (*int)(nil), ([]string)(nil)).Return(poem, nil)
+	svc.On("Create", mock.Anything, userID, "My Poem", "", domain.FormatFreeVerse, domain.ApprovalOpen, (*int)(nil), ([]string)(nil), true).Return(poem, nil)
 
 	body := `{"title":"My Poem","format":"free_verse"}`
 	r := httptest.NewRequest(http.MethodPost, "/poems", bytes.NewBufferString(body))

--- a/backend/internal/repository/poem.go
+++ b/backend/internal/repository/poem.go
@@ -29,10 +29,10 @@ func (r *PoemRepository) Create(ctx context.Context, poem *domain.Poem) error {
 	poem.UpdatedAt = now
 
 	_, err := r.pool.Exec(ctx,
-		`INSERT INTO poems (id, author_id, title, description, format, format_rules_json, approval_mode, max_stanzas, is_hall_of_fame, like_count, stanza_count, comment_count, created_at, updated_at)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)`,
+		`INSERT INTO poems (id, author_id, title, description, format, format_rules_json, approval_mode, max_stanzas, is_hall_of_fame, published, like_count, stanza_count, comment_count, created_at, updated_at)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)`,
 		poem.ID, poem.AuthorID, poem.Title, poem.Description, poem.Format, poem.FormatRulesJSON,
-		poem.ApprovalMode, poem.MaxStanzas, poem.IsHallOfFame, poem.LikeCount, poem.StanzaCount,
+		poem.ApprovalMode, poem.MaxStanzas, poem.IsHallOfFame, poem.Published, poem.LikeCount, poem.StanzaCount,
 		poem.CommentCount, poem.CreatedAt, poem.UpdatedAt,
 	)
 	return err
@@ -40,7 +40,7 @@ func (r *PoemRepository) Create(ctx context.Context, poem *domain.Poem) error {
 
 const poemSelectFields = `
 	p.id, p.author_id, p.title, p.description, p.format, p.format_rules_json,
-	p.approval_mode, p.max_stanzas, p.is_hall_of_fame, p.like_count, p.stanza_count,
+	p.approval_mode, p.max_stanzas, p.is_hall_of_fame, p.published, p.like_count, p.stanza_count,
 	p.comment_count, p.created_at, p.updated_at,
 	u.id, u.display_name, u.email, u.bio, u.avatar_url, u.is_verified, u.created_at, u.updated_at`
 
@@ -51,7 +51,7 @@ func scanPoem(row pgx.Row) (*domain.Poem, error) {
 	var author domain.User
 	err := row.Scan(
 		&p.ID, &p.AuthorID, &p.Title, &p.Description, &p.Format, &p.FormatRulesJSON,
-		&p.ApprovalMode, &p.MaxStanzas, &p.IsHallOfFame, &p.LikeCount, &p.StanzaCount,
+		&p.ApprovalMode, &p.MaxStanzas, &p.IsHallOfFame, &p.Published, &p.LikeCount, &p.StanzaCount,
 		&p.CommentCount, &p.CreatedAt, &p.UpdatedAt,
 		&author.ID, &author.DisplayName, &author.Email, &author.Bio, &author.AvatarURL,
 		&author.IsVerified, &author.CreatedAt, &author.UpdatedAt,
@@ -92,7 +92,7 @@ func (r *PoemRepository) GetByID(ctx context.Context, id uuid.UUID) (*domain.Poe
 func (r *PoemRepository) List(ctx context.Context, page domain.PaginationParams, format, sort, q, tag string) ([]domain.Poem, int, error) {
 	page.Normalize()
 
-	var conds []string
+	var conds = []string{"p.published = true"}
 	var args []any
 	var argIdx = 1
 
@@ -154,14 +154,14 @@ func (r *PoemRepository) ListByUser(ctx context.Context, userID uuid.UUID, page 
 
 	var totalCount int
 	err := r.pool.QueryRow(ctx,
-		`SELECT COUNT(*)`+poemFromJoin+` WHERE p.author_id = $1`, userID,
+		`SELECT COUNT(*)`+poemFromJoin+` WHERE p.author_id = $1 AND p.published = true`, userID,
 	).Scan(&totalCount)
 	if err != nil {
 		return nil, 0, err
 	}
 
 	rows, err := r.pool.Query(ctx,
-		`SELECT`+poemSelectFields+poemFromJoin+` WHERE p.author_id = $1 ORDER BY p.created_at DESC LIMIT $2 OFFSET $3`,
+		`SELECT`+poemSelectFields+poemFromJoin+` WHERE p.author_id = $1 AND p.published = true ORDER BY p.created_at DESC LIMIT $2 OFFSET $3`,
 		userID, page.PageSize, page.Offset(),
 	)
 	if err != nil {
@@ -179,7 +179,7 @@ func (r *PoemRepository) ListByUser(ctx context.Context, userID uuid.UUID, page 
 func (r *PoemRepository) ListFeed(ctx context.Context, userID uuid.UUID, page domain.PaginationParams) ([]domain.Poem, int, error) {
 	page.Normalize()
 
-	var feedWhere = poemFromJoin + ` WHERE p.author_id IN (SELECT followed_id FROM follows WHERE follower_id = $1)`
+	var feedWhere = poemFromJoin + ` WHERE p.published = true AND p.author_id IN (SELECT followed_id FROM follows WHERE follower_id = $1)`
 
 	var totalCount int
 	err := r.pool.QueryRow(ctx, `SELECT COUNT(*)`+feedWhere, userID).Scan(&totalCount)
@@ -206,7 +206,7 @@ func (r *PoemRepository) ListFeed(ctx context.Context, userID uuid.UUID, page do
 func (r *PoemRepository) ListExplore(ctx context.Context, page domain.PaginationParams) ([]domain.Poem, int, error) {
 	page.Normalize()
 
-	var exploreWhere = poemFromJoin + ` WHERE p.created_at > now() - interval '7 days'`
+	var exploreWhere = poemFromJoin + ` WHERE p.published = true AND p.created_at > now() - interval '7 days'`
 
 	var totalCount int
 	err := r.pool.QueryRow(ctx, `SELECT COUNT(*)`+exploreWhere).Scan(&totalCount)
@@ -233,7 +233,7 @@ func (r *PoemRepository) ListExplore(ctx context.Context, page domain.Pagination
 func (r *PoemRepository) ListHallOfFame(ctx context.Context, page domain.PaginationParams) ([]domain.Poem, int, error) {
 	page.Normalize()
 
-	var hofWhere = poemFromJoin + ` WHERE p.is_hall_of_fame = true`
+	var hofWhere = poemFromJoin + ` WHERE p.is_hall_of_fame = true AND p.published = true`
 
 	var totalCount int
 	err := r.pool.QueryRow(ctx, `SELECT COUNT(*)`+hofWhere).Scan(&totalCount)
@@ -255,6 +255,37 @@ func (r *PoemRepository) ListHallOfFame(ctx context.Context, page domain.Paginat
 		return nil, 0, err
 	}
 	return poems, totalCount, nil
+}
+
+func (r *PoemRepository) ListDrafts(ctx context.Context, userID uuid.UUID, page domain.PaginationParams) ([]domain.Poem, int, error) {
+	page.Normalize()
+
+	var draftWhere = poemFromJoin + ` WHERE p.author_id = $1 AND p.published = false`
+
+	var totalCount int
+	if err := r.pool.QueryRow(ctx, `SELECT COUNT(*)`+draftWhere, userID).Scan(&totalCount); err != nil {
+		return nil, 0, err
+	}
+
+	rows, err := r.pool.Query(ctx,
+		`SELECT`+poemSelectFields+draftWhere+` ORDER BY p.updated_at DESC LIMIT $2 OFFSET $3`,
+		userID, page.PageSize, page.Offset(),
+	)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer rows.Close()
+
+	poems, err := scanPoems(rows)
+	if err != nil {
+		return nil, 0, err
+	}
+	return poems, totalCount, nil
+}
+
+func (r *PoemRepository) Publish(ctx context.Context, id uuid.UUID) error {
+	_, err := r.pool.Exec(ctx, `UPDATE poems SET published = true, updated_at = now() WHERE id = $1`, id)
+	return err
 }
 
 func (r *PoemRepository) Update(ctx context.Context, poem *domain.Poem) error {

--- a/backend/internal/server/server.go
+++ b/backend/internal/server/server.go
@@ -109,10 +109,12 @@ func (s *Server) setupRoutes() {
 		r.Route("/poems", func(r chi.Router) {
 			r.With(optionalAuth).Get("/", poemHandler.List)
 			r.With(authMiddleware).Post("/", poemHandler.Create)
+			r.With(authMiddleware).Get("/drafts", poemHandler.Drafts)
 			r.Route("/{poemID}", func(r chi.Router) {
 				r.With(optionalAuth).Get("/", poemHandler.Get)
 				r.With(authMiddleware).Put("/", poemHandler.Update)
 				r.With(authMiddleware).Delete("/", poemHandler.Delete)
+				r.With(authMiddleware).Post("/publish", poemHandler.Publish)
 
 				// Stanzas
 				r.Get("/stanzas", poemHandler.ListStanzas)

--- a/backend/internal/service/poem.go
+++ b/backend/internal/service/poem.go
@@ -17,6 +17,8 @@ type poemStore interface {
 	ListFeed(ctx context.Context, userID uuid.UUID, page domain.PaginationParams) ([]domain.Poem, int, error)
 	ListExplore(ctx context.Context, page domain.PaginationParams) ([]domain.Poem, int, error)
 	ListHallOfFame(ctx context.Context, page domain.PaginationParams) ([]domain.Poem, int, error)
+	ListDrafts(ctx context.Context, userID uuid.UUID, page domain.PaginationParams) ([]domain.Poem, int, error)
+	Publish(ctx context.Context, id uuid.UUID) error
 	Update(ctx context.Context, poem *domain.Poem) error
 	Delete(ctx context.Context, id uuid.UUID) error
 	IncrementCounter(ctx context.Context, id uuid.UUID, column string, delta int) error
@@ -85,7 +87,7 @@ func (s *PoemService) attachTags(ctx context.Context, poems []domain.Poem) {
 	}
 }
 
-func (s *PoemService) Create(ctx context.Context, userID uuid.UUID, title, description string, format domain.PoemFormat, approvalMode domain.ApprovalMode, maxStanzas *int, tags []string) (*domain.Poem, error) {
+func (s *PoemService) Create(ctx context.Context, userID uuid.UUID, title, description string, format domain.PoemFormat, approvalMode domain.ApprovalMode, maxStanzas *int, tags []string, published bool) (*domain.Poem, error) {
 	var poem = &domain.Poem{
 		AuthorID:     userID,
 		Title:        title,
@@ -93,6 +95,7 @@ func (s *PoemService) Create(ctx context.Context, userID uuid.UUID, title, descr
 		Format:       format,
 		ApprovalMode: approvalMode,
 		MaxStanzas:   maxStanzas,
+		Published:    published,
 	}
 
 	if err := s.poems.Create(ctx, poem); err != nil {
@@ -113,6 +116,11 @@ func (s *PoemService) Get(ctx context.Context, id, viewerID uuid.UUID) (*domain.
 	poem, err := s.poems.GetByID(ctx, id)
 	if err != nil {
 		return nil, fmt.Errorf("poem not found: %w", err)
+	}
+
+	// Drafts are only visible to their author.
+	if !poem.Published && poem.AuthorID != viewerID {
+		return nil, fmt.Errorf("poem not found")
 	}
 
 	stanzas, err := s.stanzas.ListByPoem(ctx, id)
@@ -184,6 +192,26 @@ func (s *PoemService) Explore(ctx context.Context, page domain.PaginationParams)
 
 func (s *PoemService) HallOfFame(ctx context.Context, page domain.PaginationParams) ([]domain.Poem, int, error) {
 	return s.poems.ListHallOfFame(ctx, page)
+}
+
+func (s *PoemService) Drafts(ctx context.Context, userID uuid.UUID, page domain.PaginationParams) ([]domain.Poem, int, error) {
+	poems, total, err := s.poems.ListDrafts(ctx, userID, page)
+	if err != nil {
+		return nil, 0, err
+	}
+	s.attachTags(ctx, poems)
+	return poems, total, nil
+}
+
+func (s *PoemService) Publish(ctx context.Context, userID, poemID uuid.UUID) error {
+	poem, err := s.poems.GetByID(ctx, poemID)
+	if err != nil {
+		return fmt.Errorf("poem not found: %w", err)
+	}
+	if poem.AuthorID != userID {
+		return fmt.Errorf("not the poem author")
+	}
+	return s.poems.Publish(ctx, poemID)
 }
 
 func (s *PoemService) Update(ctx context.Context, userID, poemID uuid.UUID, title, description string, tags []string) error {

--- a/backend/internal/service/poem_test.go
+++ b/backend/internal/service/poem_test.go
@@ -49,6 +49,14 @@ func (m *mockPoemStore) ListHallOfFame(ctx context.Context, page domain.Paginati
 	poems, _ := args.Get(0).([]domain.Poem)
 	return poems, args.Int(1), args.Error(2)
 }
+func (m *mockPoemStore) ListDrafts(ctx context.Context, userID uuid.UUID, page domain.PaginationParams) ([]domain.Poem, int, error) {
+	args := m.Called(ctx, userID, page)
+	poems, _ := args.Get(0).([]domain.Poem)
+	return poems, args.Int(1), args.Error(2)
+}
+func (m *mockPoemStore) Publish(ctx context.Context, id uuid.UUID) error {
+	return m.Called(ctx, id).Error(0)
+}
 func (m *mockPoemStore) Update(ctx context.Context, poem *domain.Poem) error {
 	return m.Called(ctx, poem).Error(0)
 }
@@ -119,7 +127,7 @@ func TestPoemService_Create_WithTags(t *testing.T) {
 	tags.On("SetForPoem", mock.Anything, mock.Anything, []string{"nature", "haiku"}).Return(nil)
 	tags.On("ListForPoem", mock.Anything, mock.Anything).Return([]string{"haiku", "nature"}, nil)
 
-	poem, err := svc.Create(context.Background(), uuid.New(), "T", "", domain.FormatHaiku, domain.ApprovalOpen, nil, []string{"nature", "haiku"})
+	poem, err := svc.Create(context.Background(), uuid.New(), "T", "", domain.FormatHaiku, domain.ApprovalOpen, nil, []string{"nature", "haiku"}, true)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"haiku", "nature"}, poem.Tags)
 	tags.AssertCalled(t, "SetForPoem", mock.Anything, mock.Anything, []string{"nature", "haiku"})
@@ -136,7 +144,7 @@ func TestPoemService_Create_Success(t *testing.T) {
 	userID := uuid.New()
 	poems.On("Create", mock.Anything, mock.AnythingOfType("*domain.Poem")).Return(nil)
 
-	poem, err := svc.Create(context.Background(), userID, "Test Poem", "a poem", domain.FormatFreeVerse, domain.ApprovalOpen, nil, nil)
+	poem, err := svc.Create(context.Background(), userID, "Test Poem", "a poem", domain.FormatFreeVerse, domain.ApprovalOpen, nil, nil, true)
 	require.NoError(t, err)
 	assert.Equal(t, "Test Poem", poem.Title)
 	assert.Equal(t, userID, poem.AuthorID)
@@ -149,7 +157,7 @@ func TestPoemService_Create_StoreError(t *testing.T) {
 
 	poems.On("Create", mock.Anything, mock.Anything).Return(errors.New("db error"))
 
-	_, err := svc.Create(context.Background(), uuid.New(), "Title", "", domain.FormatHaiku, domain.ApprovalOpen, nil, nil)
+	_, err := svc.Create(context.Background(), uuid.New(), "Title", "", domain.FormatHaiku, domain.ApprovalOpen, nil, nil, true)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "creating poem")
 }
@@ -183,6 +191,19 @@ func TestPoemService_Get_NotFound(t *testing.T) {
 	_, err := svc.Get(context.Background(), uuid.New(), uuid.Nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "poem not found")
+}
+
+func TestPoemService_Get_DraftHiddenFromNonAuthor(t *testing.T) {
+	poems := &mockPoemStore{}
+	svc := newPoemSvc(poems, &mockStanzaStore{}, &mockPoemNotifStore{})
+
+	poemID := uuid.New()
+	draft := &domain.Poem{ID: poemID, AuthorID: uuid.New(), Published: false}
+	poems.On("GetByID", mock.Anything, poemID).Return(draft, nil)
+
+	_, err := svc.Get(context.Background(), poemID, uuid.New())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
 }
 
 // SubmitStanza tests

--- a/backend/migrations/000004_poem_drafts.down.sql
+++ b/backend/migrations/000004_poem_drafts.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS idx_poems_published;
+ALTER TABLE poems DROP COLUMN IF EXISTS published;

--- a/backend/migrations/000004_poem_drafts.up.sql
+++ b/backend/migrations/000004_poem_drafts.up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE poems ADD COLUMN published BOOLEAN NOT NULL DEFAULT true;
+
+CREATE INDEX idx_poems_published ON poems (published);


### PR DESCRIPTION
Backend for the drafts half of #77, verified green (go build/vet/test).

- Migration `000004_poem_drafts`: `published` column on poems (default true, existing poems stay published).
- Create accepts `draft: true` to save unpublished.
- Drafts are filtered out of List/search, Explore, Feed, Hall of Fame and public profiles, and the detail hides a draft from anyone but its author.
- `GET /poems/drafts` (my drafts) and `POST /poems/{poemID}/publish`.

Additive, merges ahead of the UI. Frontend (draft button, drafts page, publish) next, closing #77.

Addresses #77.