### PR TITLE
Poem drafts (frontend)

### DIFF
--- a/frontend/src/components/layout/Navbar.tsx
+++ b/frontend/src/components/layout/Navbar.tsx
@@ -39,6 +39,11 @@ export function Navbar() {
               Feed
             </Link>
           )}
+          {isAuthenticated && (
+            <Link to="/drafts" className="font-sans text-sm text-feather transition-colors hover:text-ink">
+              Drafts
+            </Link>
+          )}
         </div>
 
         <div className="hidden items-center gap-4 md:flex">
@@ -100,6 +105,15 @@ export function Navbar() {
                   className="flex min-h-[44px] items-center font-sans text-base text-feather transition-colors hover:text-ink"
                 >
                   Feed
+                </Link>
+              )}
+              {isAuthenticated && (
+                <Link
+                  to="/drafts"
+                  onClick={() => setMobileOpen(false)}
+                  className="flex min-h-[44px] items-center font-sans text-base text-feather transition-colors hover:text-ink"
+                >
+                  Drafts
                 </Link>
               )}
               {isAuthenticated && user ? (

--- a/frontend/src/components/poem/PoemDetail.tsx
+++ b/frontend/src/components/poem/PoemDetail.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import type { Poem } from '@/types/poem';
 import { useAuthStore } from '@/stores/authStore';
 import { useUIStore } from '@/stores/uiStore';
+import { usePublishPoem } from '@/hooks/usePoems';
 import { formatDate } from '@/lib/utils';
 import { PoemFormatBadge } from './PoemFormatBadge';
 import { StanzaBlock } from './StanzaBlock';
@@ -20,6 +21,7 @@ export function PoemDetail({ poem }: PoemDetailProps) {
   var [shared, setShared] = useState(false);
   var { isAuthenticated, user } = useAuthStore();
   var { openLogin } = useUIStore();
+  var publish = usePublishPoem(poem.id);
 
   async function handleShare() {
     var url = window.location.href;
@@ -97,6 +99,21 @@ export function PoemDetail({ poem }: PoemDetailProps) {
           </div>
         )}
       </header>
+
+      {isAuthor && poem.published === false && (
+        <div className="mb-6 flex flex-wrap items-center justify-between gap-3 rounded-lg border border-dashed border-accent/50 bg-accent/5 px-4 py-3">
+          <span className="font-sans text-sm text-ink">
+            This is a draft. Only you can see it.
+          </span>
+          <button
+            onClick={() => publish.mutate()}
+            disabled={publish.isPending}
+            className="btn-primary disabled:opacity-50"
+          >
+            {publish.isPending ? 'Publishing...' : 'Publish'}
+          </button>
+        </div>
+      )}
 
       {isAuthor && (
         <StanzaReviewPanel poemId={poem.id} pendingStanzas={pendingStanzas} />

--- a/frontend/src/components/poem/PoemEditor.tsx
+++ b/frontend/src/components/poem/PoemEditor.tsx
@@ -35,8 +35,7 @@ export function PoemEditor() {
   var [tags, setTags] = useState('');
   var [error, setError] = useState('');
 
-  async function handleSubmit(e: React.FormEvent) {
-    e.preventDefault();
+  async function submit(draft: boolean) {
     setError('');
 
     if (!title.trim() || !text.trim()) {
@@ -59,6 +58,7 @@ export function PoemEditor() {
         approvalMode,
         maxStanzas: maxStanzas ? Number(maxStanzas) : undefined,
         tags: parsedTags.length ? parsedTags : undefined,
+        draft,
       });
       navigate(`/poems/${poem.id}`);
     } catch (err) {
@@ -80,7 +80,7 @@ export function PoemEditor() {
           </p>
         </div>
 
-        <form onSubmit={handleSubmit} className="flex flex-col gap-5">
+        <form onSubmit={(e) => { e.preventDefault(); submit(false); }} className="flex flex-col gap-5">
           <div>
             <label htmlFor="title" className="mb-1 block font-sans text-sm font-medium text-ink">
               Title
@@ -207,13 +207,23 @@ export function PoemEditor() {
             <p className="font-sans text-sm text-error">{error}</p>
           )}
 
-          <button
-            type="submit"
-            disabled={mutation.isPending}
-            className="btn-primary disabled:opacity-50"
-          >
-            {mutation.isPending ? 'Creating...' : 'Create Poem'}
-          </button>
+          <div className="flex gap-3">
+            <button
+              type="submit"
+              disabled={mutation.isPending}
+              className="btn-primary disabled:opacity-50"
+            >
+              {mutation.isPending ? 'Saving...' : 'Publish Poem'}
+            </button>
+            <button
+              type="button"
+              onClick={() => submit(true)}
+              disabled={mutation.isPending}
+              className="btn-secondary disabled:opacity-50"
+            >
+              Save as Draft
+            </button>
+          </div>
         </form>
       </div>
     </div>

--- a/frontend/src/hooks/usePoems.ts
+++ b/frontend/src/hooks/usePoems.ts
@@ -26,6 +26,25 @@ export function usePoem(id: string) {
   });
 }
 
+export function useDrafts() {
+  return useQuery({
+    queryKey: ['drafts'],
+    queryFn: () => api.get<PaginatedResponse<Poem>>('/poems/drafts'),
+  });
+}
+
+export function usePublishPoem(poemId: string) {
+  var queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: () => api.post(`/poems/${poemId}/publish`),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['poem', poemId] });
+      queryClient.invalidateQueries({ queryKey: ['drafts'] });
+      queryClient.invalidateQueries({ queryKey: ['poems'] });
+    },
+  });
+}
+
 export function useCreatePoem() {
   var queryClient = useQueryClient();
   return useMutation({

--- a/frontend/src/pages/DraftsPage.tsx
+++ b/frontend/src/pages/DraftsPage.tsx
@@ -1,0 +1,35 @@
+import { Link } from 'react-router-dom';
+import { useDrafts } from '@/hooks/usePoems';
+import { PoemCard } from '@/components/poem/PoemCard';
+
+export function DraftsPage() {
+  var { data, isLoading } = useDrafts();
+
+  return (
+    <div>
+      <h1 className="mb-6 font-serif text-3xl font-bold text-ink">My Drafts</h1>
+
+      {isLoading ? (
+        <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <div key={i} className="card animate-pulse">
+              <div className="mb-3 h-6 w-3/4 rounded bg-parchment-dark" />
+              <div className="h-4 w-2/3 rounded bg-parchment-dark" />
+            </div>
+          ))}
+        </div>
+      ) : data && data.items.length > 0 ? (
+        <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
+          {data.items.map((poem) => (
+            <PoemCard key={poem.id} poem={poem} />
+          ))}
+        </div>
+      ) : (
+        <div className="card text-center text-feather">
+          <p className="mb-4">No drafts yet.</p>
+          <Link to="/poems/new" className="btn-primary">Start a poem</Link>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -6,6 +6,7 @@ import { PoemPage } from '@/pages/PoemPage';
 import { CreatePoemPage } from '@/pages/CreatePoemPage';
 import { HallOfFamePage } from '@/pages/HallOfFamePage';
 import { FeedPage } from '@/pages/FeedPage';
+import { DraftsPage } from '@/pages/DraftsPage';
 import { ProfilePage } from '@/pages/ProfilePage';
 import { TutorialsPage } from '@/pages/TutorialsPage';
 import { TutorialDetailPage } from '@/pages/TutorialDetailPage';
@@ -22,6 +23,7 @@ export var router = createBrowserRouter([
       { path: '/poems/:poemId', element: <PoemPage /> },
       { path: '/hall-of-fame', element: <HallOfFamePage /> },
       { path: '/feed', element: <FeedPage /> },
+      { path: '/drafts', element: <DraftsPage /> },
       { path: '/profile/:userId', element: <ProfilePage /> },
       { path: '/tutorials', element: <TutorialsPage /> },
       { path: '/tutorials/:slug', element: <TutorialDetailPage /> },

--- a/frontend/src/types/poem.ts
+++ b/frontend/src/types/poem.ts
@@ -28,6 +28,7 @@ export interface Poem {
   stanzaCount: number;
   commentCount: number;
   likedByMe?: boolean;
+  published?: boolean;
   tags?: string[];
   stanzas?: Stanza[];
   createdAt: string;
@@ -56,6 +57,7 @@ export interface CreatePoemInput {
   approvalMode: ApprovalMode;
   maxStanzas?: number;
   tags?: string[];
+  draft?: boolean;
 }
 
 export interface SubmitStanzaInput {


### PR DESCRIPTION
Frontend for the drafts half of #77, verified green (build + 55 tests). Consumes PR #84. This closes out the last of the four feature improvements.

- Editor: **Save as Draft** button beside **Publish Poem**.
- New **My Drafts** page (`/drafts`, nav link for signed-in users) listing your unpublished poems.
- A draft poem shows a "This is a draft" banner with a **Publish** button, visible only to its author.

Closes #77.