### PR TITLE
Lint cleanup + make lint a CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,6 @@ jobs:
           cache: pnpm
           cache-dependency-path: frontend/pnpm-lock.yaml
       - run: pnpm install --frozen-lockfile
+      - run: pnpm lint
       - run: pnpm build
       - run: pnpm exec vitest run
-      # lint is intentionally not a gate yet: the tree has ~219 lint errors
-      # (mostly no-var). Add `pnpm lint` here after the lint cleanup.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,7 +5,7 @@ import { router } from '@/router';
 import { ErrorBoundary } from '@/components/ErrorBoundary';
 import { useAuthStore } from '@/stores/authStore';
 
-var queryClient = new QueryClient({
+const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       staleTime: 30 * 1000,
@@ -15,7 +15,7 @@ var queryClient = new QueryClient({
 });
 
 function AuthInit() {
-  var { fetchUser } = useAuthStore();
+  const { fetchUser } = useAuthStore();
 
   useEffect(() => {
     fetchUser();

--- a/frontend/src/components/auth/LoginDialog.tsx
+++ b/frontend/src/components/auth/LoginDialog.tsx
@@ -10,13 +10,13 @@ import type { User } from '@/types/user';
 type Tab = 'magic-link' | 'passkey';
 
 export function LoginDialog() {
-  var { isLoginOpen, closeLogin } = useUIStore();
+  const { isLoginOpen, closeLogin } = useUIStore();
 
-  var [activeTab, setActiveTab] = useState<Tab>('magic-link');
-  var [email, setEmail] = useState('');
-  var [isSubmitting, setIsSubmitting] = useState(false);
-  var [successMessage, setSuccessMessage] = useState('');
-  var [error, setError] = useState('');
+  const [activeTab, setActiveTab] = useState<Tab>('magic-link');
+  const [email, setEmail] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [successMessage, setSuccessMessage] = useState('');
+  const [error, setError] = useState('');
 
   function resetState() {
     setEmail('');
@@ -55,10 +55,10 @@ export function LoginDialog() {
     setError('');
     setIsSubmitting(true);
     try {
-      var options = await api.post<Parameters<typeof startAuthentication>[0]>('/auth/login/begin');
-      var result = await startAuthentication({ optionsJSON: options as any });
-      var user = await api.post<User>('/auth/login/finish', result);
-      var { setUser } = useAuthStore.getState();
+      const optionsJSON = await api.post<Parameters<typeof startAuthentication>[0]['optionsJSON']>('/auth/login/begin');
+      const result = await startAuthentication({ optionsJSON });
+      const user = await api.post<User>('/auth/login/finish', result);
+      const { setUser } = useAuthStore.getState();
       setUser(user);
       handleClose();
     } catch (err) {

--- a/frontend/src/components/auth/MagicLinkVerify.tsx
+++ b/frontend/src/components/auth/MagicLinkVerify.tsx
@@ -4,22 +4,19 @@ import { api } from '@/lib/api';
 import { useAuthStore } from '@/stores/authStore';
 
 export function MagicLinkVerify() {
-  var [searchParams] = useSearchParams();
-  var navigate = useNavigate();
-  var { fetchUser } = useAuthStore();
-  var [error, setError] = useState('');
-  var [isVerifying, setIsVerifying] = useState(true);
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const { fetchUser } = useAuthStore();
+  const token = searchParams.get('token');
+  const [error, setError] = useState(token ? '' : 'Missing verification token.');
+  const [isVerifying, setIsVerifying] = useState(!!token);
 
   useEffect(() => {
-    var token = searchParams.get('token');
-
     if (!token) {
-      setError('Missing verification token.');
-      setIsVerifying(false);
       return;
     }
 
-    var cancelled = false;
+    let cancelled = false;
 
     async function verify() {
       try {
@@ -47,7 +44,7 @@ export function MagicLinkVerify() {
     return () => {
       cancelled = true;
     };
-  }, [searchParams, fetchUser, navigate]);
+  }, [token, fetchUser, navigate]);
 
   return (
     <div className="flex min-h-[50vh] items-center justify-center">

--- a/frontend/src/components/layout/Navbar.tsx
+++ b/frontend/src/components/layout/Navbar.tsx
@@ -6,16 +6,16 @@ import { useUIStore } from '@/stores/uiStore';
 import { NotificationsPanel } from './NotificationsPanel';
 import { cn } from '@/lib/utils';
 
-var publicLinks = [
+const publicLinks = [
   { to: '/explore', label: 'Explore' },
   { to: '/hall-of-fame', label: 'Hall of Fame' },
   { to: '/tutorials', label: 'Tutorials' },
 ];
 
 export function Navbar() {
-  var [mobileOpen, setMobileOpen] = useState(false);
-  var { user, isAuthenticated } = useAuthStore();
-  var { openLogin } = useUIStore();
+  const [mobileOpen, setMobileOpen] = useState(false);
+  const { user, isAuthenticated } = useAuthStore();
+  const { openLogin } = useUIStore();
 
   return (
     <nav className="sticky top-0 z-50 border-b border-parchment-dark bg-white/80 backdrop-blur">

--- a/frontend/src/components/layout/NotificationsPanel.test.tsx
+++ b/frontend/src/components/layout/NotificationsPanel.test.tsx
@@ -7,7 +7,7 @@ import { NotificationsPanel } from './NotificationsPanel';
 import type { Notification } from '@/types/social';
 import type { PaginatedResponse } from '@/types/api';
 
-var mockMarkRead = vi.fn();
+const mockMarkRead = vi.fn();
 
 vi.mock('@/hooks/useSocial', () => ({
   useNotifications: vi.fn(),
@@ -58,7 +58,7 @@ function makeResponse(items: Notification[]): PaginatedResponse<Notification> {
 }
 
 function renderPanel() {
-  var client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   return render(
     <MemoryRouter>
       <QueryClientProvider client={client}>
@@ -85,7 +85,7 @@ describe('NotificationsPanel', () => {
   });
 
   it('shows no badge when there are no unread notifications', () => {
-    var read = makeNotification({ read: true });
+    const read = makeNotification({ read: true });
     vi.mocked(useNotifications).mockReturnValue({
       data: makeResponse([read]),
       isLoading: false,
@@ -98,8 +98,8 @@ describe('NotificationsPanel', () => {
   });
 
   it('shows an unread badge with the correct count', () => {
-    var unread1 = makeNotification({ id: 'n-1', read: false });
-    var unread2 = makeNotification({ id: 'n-2', read: false });
+    const unread1 = makeNotification({ id: 'n-1', read: false });
+    const unread2 = makeNotification({ id: 'n-2', read: false });
     vi.mocked(useNotifications).mockReturnValue({
       data: makeResponse([unread1, unread2]),
       isLoading: false,
@@ -111,7 +111,7 @@ describe('NotificationsPanel', () => {
   });
 
   it('caps the badge at "9+" when there are more than 9 unread', () => {
-    var unread = Array.from({ length: 10 }, (_, i) =>
+    const unread = Array.from({ length: 10 }, (_, i) =>
       makeNotification({ id: `n-${i}`, read: false }),
     );
     vi.mocked(useNotifications).mockReturnValue({
@@ -125,8 +125,8 @@ describe('NotificationsPanel', () => {
   });
 
   it('opens the dropdown panel when the bell is clicked', async () => {
-    var user = userEvent.setup();
-    var notif = makeNotification();
+    const user = userEvent.setup();
+    const notif = makeNotification();
     vi.mocked(useNotifications).mockReturnValue({
       data: makeResponse([notif]),
       isLoading: false,
@@ -140,8 +140,8 @@ describe('NotificationsPanel', () => {
   });
 
   it('shows notification text in the dropdown', async () => {
-    var user = userEvent.setup();
-    var notif = makeNotification();
+    const user = userEvent.setup();
+    const notif = makeNotification();
     vi.mocked(useNotifications).mockReturnValue({
       data: makeResponse([notif]),
       isLoading: false,
@@ -156,7 +156,7 @@ describe('NotificationsPanel', () => {
   });
 
   it('shows "No notifications yet." when the list is empty', async () => {
-    var user = userEvent.setup();
+    const user = userEvent.setup();
     vi.mocked(useNotifications).mockReturnValue({
       data: makeResponse([]),
       isLoading: false,
@@ -170,8 +170,8 @@ describe('NotificationsPanel', () => {
   });
 
   it('shows an unread indicator inside the dropdown for unread notifications', async () => {
-    var user = userEvent.setup();
-    var notif = makeNotification({ read: false });
+    const user = userEvent.setup();
+    const notif = makeNotification({ read: false });
     vi.mocked(useNotifications).mockReturnValue({
       data: makeResponse([notif]),
       isLoading: false,
@@ -186,8 +186,8 @@ describe('NotificationsPanel', () => {
   });
 
   it('calls markRead with unread notification ids when the panel opens', async () => {
-    var user = userEvent.setup();
-    var notif = makeNotification({ id: 'notif-unread', read: false });
+    const user = userEvent.setup();
+    const notif = makeNotification({ id: 'notif-unread', read: false });
     vi.mocked(useNotifications).mockReturnValue({
       data: makeResponse([notif]),
       isLoading: false,
@@ -203,8 +203,8 @@ describe('NotificationsPanel', () => {
   });
 
   it('does not call markRead when all notifications are already read', async () => {
-    var user = userEvent.setup();
-    var notif = makeNotification({ read: true });
+    const user = userEvent.setup();
+    const notif = makeNotification({ read: true });
     vi.mocked(useNotifications).mockReturnValue({
       data: makeResponse([notif]),
       isLoading: false,

--- a/frontend/src/components/layout/NotificationsPanel.tsx
+++ b/frontend/src/components/layout/NotificationsPanel.tsx
@@ -6,8 +6,8 @@ import type { Notification, NotificationType } from '@/types/social';
 import { timeAgo, cn } from '@/lib/utils';
 
 function notifLabel(n: Notification): string {
-  var actor = n.actor?.displayName ?? 'Someone';
-  var title = n.poem?.title ? `"${n.poem.title}"` : 'your poem';
+  const actor = n.actor?.displayName ?? 'Someone';
+  const title = n.poem?.title ? `"${n.poem.title}"` : 'your poem';
   switch (n.type) {
     case 'like': return `${actor} liked ${title}`;
     case 'comment': return `${actor} commented on ${title}`;
@@ -54,23 +54,26 @@ function iconColorClass(type: NotificationType) {
 }
 
 export function NotificationsPanel() {
-  var [isOpen, setIsOpen] = useState(false);
-  var containerRef = useRef<HTMLDivElement>(null);
-  var navigate = useNavigate();
-  var { data, isLoading } = useNotifications({ pageSize: 20 });
-  var markRead = useMarkNotificationsRead();
+  const [isOpen, setIsOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const navigate = useNavigate();
+  const { data, isLoading } = useNotifications({ pageSize: 20 });
+  const markRead = useMarkNotificationsRead();
 
-  var notifications = data?.items ?? [];
-  var unreadCount = notifications.filter((n) => !n.read).length;
+  const notifications = data?.items ?? [];
+  const unreadCount = notifications.filter((n) => !n.read).length;
 
   useEffect(() => {
     if (!isOpen) {
       return;
     }
-    var ids = notifications.filter((n) => !n.read).map((n) => n.id);
+    const ids = notifications.filter((n) => !n.read).map((n) => n.id);
     if (ids.length > 0) {
       markRead.mutate(ids);
     }
+    // Only when the panel opens; re-running on every notifications change would
+    // re-mark repeatedly.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isOpen]);
 
   useEffect(() => {

--- a/frontend/src/components/poem/ExtendPoemDialog.tsx
+++ b/frontend/src/components/poem/ExtendPoemDialog.tsx
@@ -11,7 +11,7 @@ interface ExtendPoemDialogProps {
   onClose: () => void;
 }
 
-var literaryDevices = [
+const literaryDevices = [
   'metaphor',
   'simile',
   'alliteration',
@@ -24,9 +24,9 @@ var literaryDevices = [
 ];
 
 export function ExtendPoemDialog({ poemId, format, isOpen, onClose }: ExtendPoemDialogProps) {
-  var [text, setText] = useState('');
-  var [device, setDevice] = useState('');
-  var mutation = useSubmitStanza(poemId);
+  const [text, setText] = useState('');
+  const [device, setDevice] = useState('');
+  const mutation = useSubmitStanza(poemId);
 
   function handleBackdropClick(e: React.MouseEvent) {
     if (e.target === e.currentTarget) {

--- a/frontend/src/components/poem/PoemCard.tsx
+++ b/frontend/src/components/poem/PoemCard.tsx
@@ -8,11 +8,11 @@ interface PoemCardProps {
 }
 
 export function PoemCard({ poem }: PoemCardProps) {
-  var navigate = useNavigate();
+  const navigate = useNavigate();
 
-  var previewText = poem.stanzas?.[0]?.text ?? '';
-  var previewLines = previewText.split('\n').slice(0, 4);
-  var isTruncated = previewText.split('\n').length > 4;
+  const previewText = poem.stanzas?.[0]?.text ?? '';
+  const previewLines = previewText.split('\n').slice(0, 4);
+  const isTruncated = previewText.split('\n').length > 4;
 
   return (
     <motion.div

--- a/frontend/src/components/poem/PoemDetail.tsx
+++ b/frontend/src/components/poem/PoemDetail.tsx
@@ -17,14 +17,14 @@ interface PoemDetailProps {
 }
 
 export function PoemDetail({ poem }: PoemDetailProps) {
-  var [extendOpen, setExtendOpen] = useState(false);
-  var [shared, setShared] = useState(false);
-  var { isAuthenticated, user } = useAuthStore();
-  var { openLogin } = useUIStore();
-  var publish = usePublishPoem(poem.id);
+  const [extendOpen, setExtendOpen] = useState(false);
+  const [shared, setShared] = useState(false);
+  const { isAuthenticated, user } = useAuthStore();
+  const { openLogin } = useUIStore();
+  const publish = usePublishPoem(poem.id);
 
   async function handleShare() {
-    var url = window.location.href;
+    const url = window.location.href;
     if (navigator.share) {
       try {
         await navigator.share({ title: poem.title, url });
@@ -38,11 +38,11 @@ export function PoemDetail({ poem }: PoemDetailProps) {
     setTimeout(() => setShared(false), 2000);
   }
 
-  var stanzas = poem.stanzas ?? [];
-  var pendingStanzas = stanzas.filter((s) => s.status === 'pending');
-  var approvedStanzas = stanzas.filter((s) => s.status !== 'pending');
-  var isAuthor = isAuthenticated && user?.id === poem.authorId;
-  var canExtend =
+  const stanzas = poem.stanzas ?? [];
+  const pendingStanzas = stanzas.filter((s) => s.status === 'pending');
+  const approvedStanzas = stanzas.filter((s) => s.status !== 'pending');
+  const isAuthor = isAuthenticated && user?.id === poem.authorId;
+  const canExtend =
     poem.approvalMode !== 'closed' &&
     (!poem.maxStanzas || stanzas.length < poem.maxStanzas);
 

--- a/frontend/src/components/poem/PoemEditor.tsx
+++ b/frontend/src/components/poem/PoemEditor.tsx
@@ -6,7 +6,7 @@ import type { PoemFormat, ApprovalMode } from '@/types/poem';
 import { useCreatePoem } from '@/hooks/usePoems';
 import { formatPoemFormat } from '@/lib/utils';
 
-var allFormats: PoemFormat[] = [
+const allFormats: PoemFormat[] = [
   'free_verse',
   'haiku',
   'sonnet',
@@ -16,24 +16,24 @@ var allFormats: PoemFormat[] = [
   'custom',
 ];
 
-var approvalOptions: { value: ApprovalMode; label: string; description: string }[] = [
+const approvalOptions: { value: ApprovalMode; label: string; description: string }[] = [
   { value: 'open', label: 'Open', description: 'Anyone can add stanzas immediately' },
   { value: 'approval_required', label: 'Requires Approval', description: 'Stanzas must be approved by you' },
   { value: 'closed', label: 'Closed', description: 'No one else can add stanzas' },
 ];
 
 export function PoemEditor() {
-  var navigate = useNavigate();
-  var mutation = useCreatePoem();
+  const navigate = useNavigate();
+  const mutation = useCreatePoem();
 
-  var [title, setTitle] = useState('');
-  var [description, setDescription] = useState('');
-  var [text, setText] = useState('');
-  var [format, setFormat] = useState<PoemFormat>('free_verse');
-  var [approvalMode, setApprovalMode] = useState<ApprovalMode>('open');
-  var [maxStanzas, setMaxStanzas] = useState('');
-  var [tags, setTags] = useState('');
-  var [error, setError] = useState('');
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [text, setText] = useState('');
+  const [format, setFormat] = useState<PoemFormat>('free_verse');
+  const [approvalMode, setApprovalMode] = useState<ApprovalMode>('open');
+  const [maxStanzas, setMaxStanzas] = useState('');
+  const [tags, setTags] = useState('');
+  const [error, setError] = useState('');
 
   async function submit(draft: boolean) {
     setError('');
@@ -43,14 +43,14 @@ export function PoemEditor() {
       return;
     }
 
-    var parsedTags = tags
+    const parsedTags = tags
       .split(',')
       .map((t) => t.trim())
       .filter(Boolean)
       .slice(0, 10);
 
     try {
-      var poem = await mutation.mutateAsync({
+      const poem = await mutation.mutateAsync({
         title: title.trim(),
         description: description.trim() || undefined,
         text: text.trim(),

--- a/frontend/src/components/poem/PoemFormatBadge.tsx
+++ b/frontend/src/components/poem/PoemFormatBadge.tsx
@@ -1,7 +1,7 @@
 import type { PoemFormat } from '@/types/poem';
 import { formatPoemFormat, cn } from '@/lib/utils';
 
-var formatColors: Record<PoemFormat, string> = {
+const formatColors: Record<PoemFormat, string> = {
   free_verse: 'bg-blue-100 text-blue-800',
   haiku: 'bg-emerald-100 text-emerald-800',
   sonnet: 'bg-purple-100 text-purple-800',

--- a/frontend/src/components/poem/StanzaBlock.tsx
+++ b/frontend/src/components/poem/StanzaBlock.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import type { Stanza } from '@/types/poem';
 import { useToggleStanzaLike } from '@/hooks/useSocial';
@@ -10,7 +10,7 @@ interface StanzaBlockProps {
   isLast?: boolean;
 }
 
-var deviceColors: Record<string, string> = {
+const deviceColors: Record<string, string> = {
   metaphor: 'bg-purple-100 text-purple-700',
   simile: 'bg-blue-100 text-blue-700',
   alliteration: 'bg-emerald-100 text-emerald-700',
@@ -20,27 +20,27 @@ var deviceColors: Record<string, string> = {
 };
 
 export function StanzaBlock({ stanza, isLast }: StanzaBlockProps) {
-  var { isAuthenticated } = useAuthStore();
-  var { openLogin } = useUIStore();
-  var mutation = useToggleStanzaLike(stanza.poemId, stanza.id);
-  var [liked, setLiked] = useState(stanza.likedByMe ?? false);
-  var [count, setCount] = useState(stanza.likeCount);
+  const { isAuthenticated } = useAuthStore();
+  const { openLogin } = useUIStore();
+  const mutation = useToggleStanzaLike(stanza.poemId, stanza.id);
+  const [liked, setLiked] = useState(stanza.likedByMe ?? false);
+  const [count, setCount] = useState(stanza.likeCount);
 
-  // Resync to server state after a refetch (see the poem like button).
-  useEffect(() => {
-    if (mutation.isPending) {
-      return;
-    }
+  // Resync to server state after a refetch, adjusting state during render
+  // rather than in an effect (see the poem like button).
+  const [synced, setSynced] = useState({ liked: stanza.likedByMe ?? false, count: stanza.likeCount });
+  if (!mutation.isPending && (synced.liked !== (stanza.likedByMe ?? false) || synced.count !== stanza.likeCount)) {
+    setSynced({ liked: stanza.likedByMe ?? false, count: stanza.likeCount });
     setLiked(stanza.likedByMe ?? false);
     setCount(stanza.likeCount);
-  }, [stanza.likedByMe, stanza.likeCount, mutation.isPending]);
+  }
 
   function toggleLike() {
     if (!isAuthenticated) {
       openLogin();
       return;
     }
-    var next = !liked;
+    const next = !liked;
     setLiked(next);
     setCount((c) => c + (next ? 1 : -1));
     mutation.mutate(undefined, {

--- a/frontend/src/components/poem/StanzaReviewPanel.test.tsx
+++ b/frontend/src/components/poem/StanzaReviewPanel.test.tsx
@@ -5,7 +5,7 @@ import { StanzaReviewPanel } from './StanzaReviewPanel';
 import type { Stanza } from '@/types/poem';
 
 // useReviewStanza is mocked so the component never hits the network.
-var mockMutate = vi.fn();
+const mockMutate = vi.fn();
 
 vi.mock('@/hooks/usePoems', () => ({
   useReviewStanza: vi.fn(() => ({
@@ -16,7 +16,7 @@ vi.mock('@/hooks/usePoems', () => ({
 
 import { useReviewStanza } from '@/hooks/usePoems';
 
-var pendingStanzas: Stanza[] = [
+const pendingStanzas: Stanza[] = [
   {
     id: 'stanza-1',
     poemId: 'poem-1',
@@ -66,7 +66,7 @@ beforeEach(() => {
 
 describe('StanzaReviewPanel', () => {
   it('renders nothing when there are no pending stanzas', () => {
-    var { container } = render(
+    const { container } = render(
       <StanzaReviewPanel poemId="poem-1" pendingStanzas={[]} />,
     );
     expect(container.firstChild).toBeNull();
@@ -101,7 +101,7 @@ describe('StanzaReviewPanel', () => {
   });
 
   it('calls mutate with approved: true when Approve is clicked', async () => {
-    var user = userEvent.setup();
+    const user = userEvent.setup();
     render(<StanzaReviewPanel poemId="poem-1" pendingStanzas={[pendingStanzas[0]]} />);
 
     await user.click(screen.getByRole('button', { name: /approve/i }));
@@ -110,7 +110,7 @@ describe('StanzaReviewPanel', () => {
   });
 
   it('calls mutate with approved: false when Reject is clicked', async () => {
-    var user = userEvent.setup();
+    const user = userEvent.setup();
     render(<StanzaReviewPanel poemId="poem-1" pendingStanzas={[pendingStanzas[0]]} />);
 
     await user.click(screen.getByRole('button', { name: /reject/i }));
@@ -131,7 +131,7 @@ describe('StanzaReviewPanel', () => {
 
     render(<StanzaReviewPanel poemId="poem-1" pendingStanzas={[pendingStanzas[0]]} />);
 
-    for (var btn of screen.getAllByRole('button')) {
+    for (const btn of screen.getAllByRole('button')) {
       expect(btn).toBeDisabled();
     }
   });

--- a/frontend/src/components/poem/StanzaReviewPanel.tsx
+++ b/frontend/src/components/poem/StanzaReviewPanel.tsx
@@ -7,7 +7,7 @@ interface Props {
 }
 
 export function StanzaReviewPanel({ poemId, pendingStanzas }: Props) {
-  var reviewStanza = useReviewStanza(poemId);
+  const reviewStanza = useReviewStanza(poemId);
 
   if (pendingStanzas.length === 0) {
     return null;

--- a/frontend/src/components/social/CommentThread.tsx
+++ b/frontend/src/components/social/CommentThread.tsx
@@ -10,13 +10,13 @@ interface CommentThreadProps {
 }
 
 export function CommentThread({ poemId }: CommentThreadProps) {
-  var [text, setText] = useState('');
-  var { data, isLoading } = useComments(poemId);
-  var addComment = useAddComment(poemId);
-  var { isAuthenticated } = useAuthStore();
-  var { openLogin } = useUIStore();
+  const [text, setText] = useState('');
+  const { data, isLoading } = useComments(poemId);
+  const addComment = useAddComment(poemId);
+  const { isAuthenticated } = useAuthStore();
+  const { openLogin } = useUIStore();
 
-  var comments = data?.items ?? [];
+  const comments = data?.items ?? [];
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();

--- a/frontend/src/components/social/LikeButton.tsx
+++ b/frontend/src/components/social/LikeButton.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useToggleLike } from '@/hooks/useSocial';
 import { useAuthStore } from '@/stores/authStore';
@@ -11,22 +11,22 @@ interface LikeButtonProps {
 }
 
 export function LikeButton({ poemId, likeCount, isLiked: initialLiked }: LikeButtonProps) {
-  var [optimisticLiked, setOptimisticLiked] = useState(initialLiked ?? false);
-  var [optimisticCount, setOptimisticCount] = useState(likeCount);
-  var [animKey, setAnimKey] = useState(0);
-  var mutation = useToggleLike(poemId);
-  var { isAuthenticated } = useAuthStore();
-  var { openLogin } = useUIStore();
+  const mutation = useToggleLike(poemId);
+  const { isAuthenticated } = useAuthStore();
+  const { openLogin } = useUIStore();
+  const [optimisticLiked, setOptimisticLiked] = useState(initialLiked ?? false);
+  const [optimisticCount, setOptimisticCount] = useState(likeCount);
+  const [animKey, setAnimKey] = useState(0);
 
   // Resync to server truth when fresh props arrive (e.g. after a refetch),
-  // but not mid-mutation or the optimistic update would be clobbered.
-  useEffect(() => {
-    if (mutation.isPending) {
-      return;
-    }
+  // adjusting state during render (not in an effect). Skip mid-mutation or the
+  // optimistic update would be clobbered.
+  const [synced, setSynced] = useState({ liked: initialLiked ?? false, count: likeCount });
+  if (!mutation.isPending && (synced.liked !== (initialLiked ?? false) || synced.count !== likeCount)) {
+    setSynced({ liked: initialLiked ?? false, count: likeCount });
     setOptimisticLiked(initialLiked ?? false);
     setOptimisticCount(likeCount);
-  }, [initialLiked, likeCount, mutation.isPending]);
+  }
 
   function handleClick() {
     if (!isAuthenticated) {
@@ -34,7 +34,7 @@ export function LikeButton({ poemId, likeCount, isLiked: initialLiked }: LikeBut
       return;
     }
 
-    var nextLiked = !optimisticLiked;
+    const nextLiked = !optimisticLiked;
     setOptimisticLiked(nextLiked);
     setOptimisticCount((c) => c + (nextLiked ? 1 : -1));
 

--- a/frontend/src/hooks/usePageMeta.ts
+++ b/frontend/src/hooks/usePageMeta.ts
@@ -1,10 +1,10 @@
 import { useEffect } from 'react';
 
 function setMeta(selector: string, attr: string, value: string) {
-  var el = document.head.querySelector<HTMLMetaElement>(selector);
+  let el = document.head.querySelector<HTMLMetaElement>(selector);
   if (!el) {
     el = document.createElement('meta');
-    var [name, key] = attr.split('=');
+    const [name, key] = attr.split('=');
     el.setAttribute(name, key.replace(/"/g, ''));
     document.head.appendChild(el);
   }
@@ -16,7 +16,7 @@ function setMeta(selector: string, attr: string, value: string) {
 // function. Restores the site defaults on unmount.
 export function usePageMeta(title: string, description?: string) {
   useEffect(() => {
-    var previousTitle = document.title;
+    const previousTitle = document.title;
     document.title = title;
 
     if (description) {

--- a/frontend/src/hooks/usePoems.test.ts
+++ b/frontend/src/hooks/usePoems.test.ts
@@ -7,7 +7,7 @@ import { usePoem, usePoems, useReviewStanza } from './usePoems';
 import type { Poem, Stanza } from '@/types/poem';
 import type { PaginatedResponse } from '@/types/api';
 
-var mockPoem: Poem = {
+const mockPoem: Poem = {
   id: 'poem-1',
   authorId: 'user-1',
   title: 'Ode to a Nightingale',
@@ -22,7 +22,7 @@ var mockPoem: Poem = {
   updatedAt: '2024-01-01T00:00:00Z',
 };
 
-var mockPoems: PaginatedResponse<Poem> = {
+const mockPoems: PaginatedResponse<Poem> = {
   items: [mockPoem],
   totalCount: 1,
   page: 1,
@@ -47,7 +47,7 @@ beforeEach(() => {
 
 describe('usePoems', () => {
   it('returns a list of poems', async () => {
-    var { result } = renderHook(() => usePoems(), { wrapper: Wrapper });
+    const { result } = renderHook(() => usePoems(), { wrapper: Wrapper });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
@@ -56,7 +56,7 @@ describe('usePoems', () => {
   });
 
   it('exposes totalCount from the paginated response', async () => {
-    var { result } = renderHook(() => usePoems(), { wrapper: Wrapper });
+    const { result } = renderHook(() => usePoems(), { wrapper: Wrapper });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
@@ -64,7 +64,7 @@ describe('usePoems', () => {
   });
 
   it('builds query params when format is supplied', async () => {
-    var capturedUrl = '';
+    let capturedUrl = '';
     server.use(
       http.get('/api/v1/poems', ({ request }) => {
         capturedUrl = request.url;
@@ -72,7 +72,7 @@ describe('usePoems', () => {
       }),
     );
 
-    var { result } = renderHook(() => usePoems({ format: 'haiku', page: 2 }), {
+    const { result } = renderHook(() => usePoems({ format: 'haiku', page: 2 }), {
       wrapper: Wrapper,
     });
 
@@ -85,7 +85,7 @@ describe('usePoems', () => {
 
 describe('usePoem', () => {
   it('returns the poem matching the supplied id', async () => {
-    var { result } = renderHook(() => usePoem('poem-1'), { wrapper: Wrapper });
+    const { result } = renderHook(() => usePoem('poem-1'), { wrapper: Wrapper });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
@@ -94,7 +94,7 @@ describe('usePoem', () => {
   });
 
   it('does not fetch when id is empty', () => {
-    var { result } = renderHook(() => usePoem(''), { wrapper: Wrapper });
+    const { result } = renderHook(() => usePoem(''), { wrapper: Wrapper });
 
     // enabled: !!id means query stays idle.
     expect(result.current.fetchStatus).toBe('idle');
@@ -103,16 +103,16 @@ describe('usePoem', () => {
 
 describe('useReviewStanza', () => {
   it('sends PUT with approved: true when approving a stanza', async () => {
-    var capturedBody: unknown;
+    let capturedBody: unknown;
     server.use(
       http.put('/api/v1/poems/poem-1/stanzas/stanza-1', async ({ request }) => {
         capturedBody = await request.json();
-        var stanza: Partial<Stanza> = { id: 'stanza-1', status: 'approved' };
+        const stanza: Partial<Stanza> = { id: 'stanza-1', status: 'approved' };
         return apiJson(stanza);
       }),
     );
 
-    var { result } = renderHook(() => useReviewStanza('poem-1'), { wrapper: Wrapper });
+    const { result } = renderHook(() => useReviewStanza('poem-1'), { wrapper: Wrapper });
 
     result.current.mutate({ stanzaId: 'stanza-1', approved: true });
 
@@ -122,16 +122,16 @@ describe('useReviewStanza', () => {
   });
 
   it('sends PUT with approved: false when rejecting a stanza', async () => {
-    var capturedBody: unknown;
+    let capturedBody: unknown;
     server.use(
       http.put('/api/v1/poems/poem-1/stanzas/stanza-2', async ({ request }) => {
         capturedBody = await request.json();
-        var stanza: Partial<Stanza> = { id: 'stanza-2', status: 'rejected' };
+        const stanza: Partial<Stanza> = { id: 'stanza-2', status: 'rejected' };
         return apiJson(stanza);
       }),
     );
 
-    var { result } = renderHook(() => useReviewStanza('poem-1'), { wrapper: Wrapper });
+    const { result } = renderHook(() => useReviewStanza('poem-1'), { wrapper: Wrapper });
 
     result.current.mutate({ stanzaId: 'stanza-2', approved: false });
 
@@ -141,16 +141,16 @@ describe('useReviewStanza', () => {
   });
 
   it('hits the correct URL including poemId and stanzaId', async () => {
-    var capturedUrl = '';
+    let capturedUrl = '';
     server.use(
       http.put('/api/v1/poems/:poemId/stanzas/:stanzaId', ({ request, params }) => {
         capturedUrl = request.url;
-        var stanza: Partial<Stanza> = { id: params.stanzaId as string };
+        const stanza: Partial<Stanza> = { id: params.stanzaId as string };
         return apiJson(stanza);
       }),
     );
 
-    var { result } = renderHook(() => useReviewStanza('poem-42'), { wrapper: Wrapper });
+    const { result } = renderHook(() => useReviewStanza('poem-42'), { wrapper: Wrapper });
 
     result.current.mutate({ stanzaId: 'stanza-99', approved: true });
 

--- a/frontend/src/hooks/usePoems.ts
+++ b/frontend/src/hooks/usePoems.ts
@@ -4,7 +4,7 @@ import type { Poem, CreatePoemInput, SubmitStanzaInput, Stanza } from '@/types/p
 import type { PaginatedResponse, PaginationParams } from '@/types/api';
 
 export function usePoems(params?: PaginationParams & { format?: string; sort?: string; q?: string; tag?: string }) {
-  var query = new URLSearchParams();
+  const query = new URLSearchParams();
   if (params?.page) { query.set('page', String(params.page)); }
   if (params?.pageSize) { query.set('pageSize', String(params.pageSize)); }
   if (params?.format) { query.set('format', params.format); }
@@ -34,7 +34,7 @@ export function useDrafts() {
 }
 
 export function usePublishPoem(poemId: string) {
-  var queryClient = useQueryClient();
+  const queryClient = useQueryClient();
   return useMutation({
     mutationFn: () => api.post(`/poems/${poemId}/publish`),
     onSuccess: () => {
@@ -46,7 +46,7 @@ export function usePublishPoem(poemId: string) {
 }
 
 export function useCreatePoem() {
-  var queryClient = useQueryClient();
+  const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (input: CreatePoemInput) => api.post<Poem>('/poems', input),
     onSuccess: () => {
@@ -56,7 +56,7 @@ export function useCreatePoem() {
 }
 
 export function useSubmitStanza(poemId: string) {
-  var queryClient = useQueryClient();
+  const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (input: SubmitStanzaInput) =>
       api.post<Stanza>(`/poems/${poemId}/stanzas`, input),
@@ -96,7 +96,7 @@ export function useUserPoems(userId: string, params?: PaginationParams) {
 }
 
 export function useReviewStanza(poemId: string) {
-  var queryClient = useQueryClient();
+  const queryClient = useQueryClient();
   return useMutation({
     mutationFn: ({ stanzaId, approved }: { stanzaId: string; approved: boolean }) =>
       api.put(`/poems/${poemId}/stanzas/${stanzaId}`, { approved }),

--- a/frontend/src/hooks/useSocial.test.ts
+++ b/frontend/src/hooks/useSocial.test.ts
@@ -11,7 +11,7 @@ function apiJson<T>(data: T) {
   return HttpResponse.json({ data });
 }
 
-var mockNotifications: PaginatedResponse<Notification> = {
+const mockNotifications: PaginatedResponse<Notification> = {
   items: [
     {
       id: 'notif-1',
@@ -57,7 +57,7 @@ beforeEach(() => {
 
 describe('useNotifications', () => {
   it('returns paginated notification items', async () => {
-    var { result } = renderHook(() => useNotifications(), { wrapper: Wrapper });
+    const { result } = renderHook(() => useNotifications(), { wrapper: Wrapper });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
@@ -66,21 +66,21 @@ describe('useNotifications', () => {
   });
 
   it('includes the notification type and read flag', async () => {
-    var { result } = renderHook(() => useNotifications(), { wrapper: Wrapper });
+    const { result } = renderHook(() => useNotifications(), { wrapper: Wrapper });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    var first = result.current.data!.items[0];
+    const first = result.current.data!.items[0];
     expect(first.type).toBe('like');
     expect(first.read).toBe(false);
 
-    var second = result.current.data!.items[1];
+    const second = result.current.data!.items[1];
     expect(second.type).toBe('follow');
     expect(second.read).toBe(true);
   });
 
   it('passes the page param in the query string', async () => {
-    var capturedUrl = '';
+    let capturedUrl = '';
     server.use(
       http.get('/api/v1/notifications', ({ request }) => {
         capturedUrl = request.url;
@@ -88,7 +88,7 @@ describe('useNotifications', () => {
       }),
     );
 
-    var { result } = renderHook(() => useNotifications({ page: 3 }), { wrapper: Wrapper });
+    const { result } = renderHook(() => useNotifications({ page: 3 }), { wrapper: Wrapper });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
@@ -98,7 +98,7 @@ describe('useNotifications', () => {
 
 describe('useToggleFollow', () => {
   it('calls POST /api/v1/users/:userId/follow', async () => {
-    var capturedUrl = '';
+    let capturedUrl = '';
     server.use(
       http.post('/api/v1/users/:userId/follow', ({ request }) => {
         capturedUrl = request.url;
@@ -106,7 +106,7 @@ describe('useToggleFollow', () => {
       }),
     );
 
-    var { result } = renderHook(() => useToggleFollow('user-99'), { wrapper: Wrapper });
+    const { result } = renderHook(() => useToggleFollow('user-99'), { wrapper: Wrapper });
 
     result.current.mutate();
 
@@ -120,7 +120,7 @@ describe('useToggleFollow', () => {
       http.post('/api/v1/users/:userId/follow', () => apiJson({ following: false })),
     );
 
-    var { result } = renderHook(() => useToggleFollow('user-5'), { wrapper: Wrapper });
+    const { result } = renderHook(() => useToggleFollow('user-5'), { wrapper: Wrapper });
 
     result.current.mutate();
 

--- a/frontend/src/hooks/useSocial.ts
+++ b/frontend/src/hooks/useSocial.ts
@@ -5,7 +5,7 @@ import type { User } from '@/types/user';
 import type { PaginatedResponse, PaginationParams } from '@/types/api';
 
 export function useToggleLike(poemId: string) {
-  var queryClient = useQueryClient();
+  const queryClient = useQueryClient();
   return useMutation({
     mutationFn: () => api.post<{ liked: boolean }>(`/poems/${poemId}/like`),
     onSuccess: () => {
@@ -16,7 +16,7 @@ export function useToggleLike(poemId: string) {
 }
 
 export function useToggleStanzaLike(poemId: string, stanzaId: string) {
-  var queryClient = useQueryClient();
+  const queryClient = useQueryClient();
   return useMutation({
     mutationFn: () => api.post<{ liked: boolean }>(`/poems/${poemId}/stanzas/${stanzaId}/like`),
     onSuccess: () => {
@@ -34,7 +34,7 @@ export function useComments(poemId: string, params?: PaginationParams) {
 }
 
 export function useAddComment(poemId: string) {
-  var queryClient = useQueryClient();
+  const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (input: { text: string; parentId?: string }) =>
       api.post<Comment>(`/poems/${poemId}/comments`, input),
@@ -46,7 +46,7 @@ export function useAddComment(poemId: string) {
 }
 
 export function useToggleFollow(userId: string) {
-  var queryClient = useQueryClient();
+  const queryClient = useQueryClient();
   return useMutation({
     mutationFn: () => api.post<{ following: boolean }>(`/users/${userId}/follow`),
     onSuccess: () => {
@@ -80,7 +80,7 @@ export function useUserProfile(userId: string) {
 }
 
 export function useUpdateProfile() {
-  var queryClient = useQueryClient();
+  const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (input: { displayName: string; bio: string; avatarUrl: string }) =>
       api.put('/users/me', input),
@@ -99,7 +99,7 @@ export function useNotifications(params?: PaginationParams) {
 }
 
 export function useMarkNotificationsRead() {
-  var queryClient = useQueryClient();
+  const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (ids: string[]) => api.post('/notifications/read', { ids }),
     onSuccess: () => {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -4,7 +4,7 @@ const BASE_URL = '/api/v1';
 
 class ApiClient {
   private async request<T>(path: string, options: RequestInit = {}): Promise<T> {
-    var response = await fetch(`${BASE_URL}${path}`, {
+    const response = await fetch(`${BASE_URL}${path}`, {
       credentials: 'include',
       headers: {
         'Content-Type': 'application/json',
@@ -13,7 +13,7 @@ class ApiClient {
       ...options,
     });
 
-    var json: ApiResponse<T> = await response.json();
+    const json: ApiResponse<T> = await response.json();
 
     if (!response.ok || json.error) {
       throw new Error(json.error || `Request failed: ${response.status}`);

--- a/frontend/src/lib/utils.test.ts
+++ b/frontend/src/lib/utils.test.ts
@@ -3,23 +3,23 @@ import { formatDate, timeAgo, formatPoemFormat } from './utils';
 
 describe('formatDate', () => {
   it('formats an ISO date string to a readable US date', () => {
-    var result = formatDate('2024-03-15T12:00:00Z');
+    const result = formatDate('2024-03-15T12:00:00Z');
     expect(result).toBe('March 15, 2024');
   });
 
   it('handles dates at the start of the year', () => {
-    var result = formatDate('2023-01-01T00:00:00Z');
+    const result = formatDate('2023-01-01T00:00:00Z');
     expect(result).toBe('January 1, 2023');
   });
 
   it('handles dates at the end of the year', () => {
-    var result = formatDate('2022-12-31T23:59:59Z');
+    const result = formatDate('2022-12-31T23:59:59Z');
     expect(result).toBe('December 31, 2022');
   });
 });
 
 describe('timeAgo', () => {
-  var realDateNow: () => number;
+  let realDateNow: () => number;
 
   beforeEach(() => {
     realDateNow = Date.now;
@@ -30,39 +30,39 @@ describe('timeAgo', () => {
   });
 
   it('returns "just now" for dates less than 60 seconds ago', () => {
-    var now = new Date('2024-06-01T12:00:00Z').getTime();
+    const now = new Date('2024-06-01T12:00:00Z').getTime();
     Date.now = vi.fn(() => now + 30_000);
     expect(timeAgo('2024-06-01T12:00:00Z')).toBe('just now');
   });
 
   it('returns minutes for dates between 1 and 59 minutes ago', () => {
-    var now = new Date('2024-06-01T12:00:00Z').getTime();
+    const now = new Date('2024-06-01T12:00:00Z').getTime();
     Date.now = vi.fn(() => now + 5 * 60 * 1000);
     expect(timeAgo('2024-06-01T12:00:00Z')).toBe('5m ago');
   });
 
   it('returns "1m ago" at exactly 60 seconds', () => {
-    var now = new Date('2024-06-01T12:00:00Z').getTime();
+    const now = new Date('2024-06-01T12:00:00Z').getTime();
     Date.now = vi.fn(() => now + 60_000);
     expect(timeAgo('2024-06-01T12:00:00Z')).toBe('1m ago');
   });
 
   it('returns hours for dates between 1 and 23 hours ago', () => {
-    var now = new Date('2024-06-01T12:00:00Z').getTime();
+    const now = new Date('2024-06-01T12:00:00Z').getTime();
     Date.now = vi.fn(() => now + 3 * 3600 * 1000);
     expect(timeAgo('2024-06-01T12:00:00Z')).toBe('3h ago');
   });
 
   it('returns days for dates between 1 and 6 days ago', () => {
-    var now = new Date('2024-06-01T12:00:00Z').getTime();
+    const now = new Date('2024-06-01T12:00:00Z').getTime();
     Date.now = vi.fn(() => now + 4 * 86400 * 1000);
     expect(timeAgo('2024-06-01T12:00:00Z')).toBe('4d ago');
   });
 
   it('falls back to formatDate for dates 7 or more days ago', () => {
-    var now = new Date('2024-06-01T12:00:00Z').getTime();
+    const now = new Date('2024-06-01T12:00:00Z').getTime();
     Date.now = vi.fn(() => now + 8 * 86400 * 1000);
-    var result = timeAgo('2024-06-01T12:00:00Z');
+    const result = timeAgo('2024-06-01T12:00:00Z');
     expect(result).toBe('June 1, 2024');
   });
 });

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -14,21 +14,21 @@ export function formatDate(dateStr: string): string {
 }
 
 export function timeAgo(dateStr: string): string {
-  var seconds = Math.floor((Date.now() - new Date(dateStr).getTime()) / 1000);
+  const seconds = Math.floor((Date.now() - new Date(dateStr).getTime()) / 1000);
 
   if (seconds < 60) {
     return 'just now';
   }
   if (seconds < 3600) {
-    var minutes = Math.floor(seconds / 60);
+    const minutes = Math.floor(seconds / 60);
     return `${minutes}m ago`;
   }
   if (seconds < 86400) {
-    var hours = Math.floor(seconds / 3600);
+    const hours = Math.floor(seconds / 3600);
     return `${hours}h ago`;
   }
   if (seconds < 604800) {
-    var days = Math.floor(seconds / 86400);
+    const days = Math.floor(seconds / 86400);
     return `${days}d ago`;
   }
   return formatDate(dateStr);

--- a/frontend/src/pages/CreatePoemPage.tsx
+++ b/frontend/src/pages/CreatePoemPage.tsx
@@ -3,7 +3,7 @@ import { useAuthStore } from '@/stores/authStore';
 import { PoemEditor } from '@/components/poem/PoemEditor';
 
 export function CreatePoemPage() {
-  var { isAuthenticated, isLoading } = useAuthStore();
+  const { isAuthenticated, isLoading } = useAuthStore();
 
   if (isLoading) {
     return null;

--- a/frontend/src/pages/DraftsPage.tsx
+++ b/frontend/src/pages/DraftsPage.tsx
@@ -3,7 +3,7 @@ import { useDrafts } from '@/hooks/usePoems';
 import { PoemCard } from '@/components/poem/PoemCard';
 
 export function DraftsPage() {
-  var { data, isLoading } = useDrafts();
+  const { data, isLoading } = useDrafts();
 
   return (
     <div>

--- a/frontend/src/pages/ExplorePage.tsx
+++ b/frontend/src/pages/ExplorePage.tsx
@@ -6,7 +6,7 @@ import { PoemCard } from '@/components/poem/PoemCard';
 import { formatPoemFormat } from '@/lib/utils';
 import type { PoemFormat } from '@/types/poem';
 
-var formats: (PoemFormat | 'all')[] = [
+const formats: (PoemFormat | 'all')[] = [
   'all',
   'free_verse',
   'haiku',
@@ -19,16 +19,16 @@ var formats: (PoemFormat | 'all')[] = [
 type SortOption = 'recent' | 'popular';
 
 export function ExplorePage() {
-  var [searchParams, setSearchParams] = useSearchParams();
-  var q = searchParams.get('q') ?? '';
-  var tag = searchParams.get('tag') ?? '';
+  const [searchParams, setSearchParams] = useSearchParams();
+  const q = searchParams.get('q') ?? '';
+  const tag = searchParams.get('tag') ?? '';
 
-  var [page, setPage] = useState(1);
-  var [format, setFormat] = useState<PoemFormat | 'all'>('all');
-  var [sort, setSort] = useState<SortOption>('recent');
-  var [input, setInput] = useState(q);
+  const [page, setPage] = useState(1);
+  const [format, setFormat] = useState<PoemFormat | 'all'>('all');
+  const [sort, setSort] = useState<SortOption>('recent');
+  const [input, setInput] = useState(q);
 
-  var { data, isLoading } = usePoems({
+  const { data, isLoading } = usePoems({
     page,
     pageSize: 12,
     format: format === 'all' ? undefined : format,
@@ -39,7 +39,7 @@ export function ExplorePage() {
 
   function submitSearch(e: React.FormEvent) {
     e.preventDefault();
-    var next = new URLSearchParams(searchParams);
+    const next = new URLSearchParams(searchParams);
     if (input.trim()) {
       next.set('q', input.trim());
     } else {
@@ -50,13 +50,13 @@ export function ExplorePage() {
   }
 
   function clearTag() {
-    var next = new URLSearchParams(searchParams);
+    const next = new URLSearchParams(searchParams);
     next.delete('tag');
     setSearchParams(next);
     setPage(1);
   }
 
-  var totalPages = data ? Math.ceil(data.totalCount / data.pageSize) : 0;
+  const totalPages = data ? Math.ceil(data.totalCount / data.pageSize) : 0;
 
   return (
     <div>

--- a/frontend/src/pages/FeedPage.tsx
+++ b/frontend/src/pages/FeedPage.tsx
@@ -6,10 +6,10 @@ import { useAuthStore } from '@/stores/authStore';
 import { PoemCard } from '@/components/poem/PoemCard';
 
 export function FeedPage() {
-  var { isAuthenticated, isLoading: authLoading } = useAuthStore();
-  var [page, setPage] = useState(1);
-  var { data, isLoading } = useFeed({ page, pageSize: 12 });
-  var totalPages = data ? Math.ceil(data.totalCount / data.pageSize) : 0;
+  const { isAuthenticated, isLoading: authLoading } = useAuthStore();
+  const [page, setPage] = useState(1);
+  const { data, isLoading } = useFeed({ page, pageSize: 12 });
+  const totalPages = data ? Math.ceil(data.totalCount / data.pageSize) : 0;
 
   if (authLoading) {
     return null;

--- a/frontend/src/pages/HallOfFamePage.tsx
+++ b/frontend/src/pages/HallOfFamePage.tsx
@@ -4,9 +4,9 @@ import { useHallOfFame } from '@/hooks/usePoems';
 import { PoemCard } from '@/components/poem/PoemCard';
 
 export function HallOfFamePage() {
-  var [page, setPage] = useState(1);
-  var { data, isLoading } = useHallOfFame({ page, pageSize: 12 });
-  var totalPages = data ? Math.ceil(data.totalCount / data.pageSize) : 0;
+  const [page, setPage] = useState(1);
+  const { data, isLoading } = useHallOfFame({ page, pageSize: 12 });
+  const totalPages = data ? Math.ceil(data.totalCount / data.pageSize) : 0;
 
   return (
     <div>

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -5,7 +5,7 @@ import { useAuthStore } from '@/stores/authStore';
 import { useUIStore } from '@/stores/uiStore';
 import { PoemCard } from '@/components/poem/PoemCard';
 
-var container = {
+const container = {
   hidden: { opacity: 0 },
   show: {
     opacity: 1,
@@ -13,16 +13,16 @@ var container = {
   },
 };
 
-var item = {
+const item = {
   hidden: { opacity: 0, y: 20 },
   show: { opacity: 1, y: 0 },
 };
 
 export function HomePage() {
-  var { isAuthenticated } = useAuthStore();
-  var { openLogin } = useUIStore();
-  var navigate = useNavigate();
-  var { data, isLoading } = useExplore({ page: 1, pageSize: 6 });
+  const { isAuthenticated } = useAuthStore();
+  const { openLogin } = useUIStore();
+  const navigate = useNavigate();
+  const { data, isLoading } = useExplore({ page: 1, pageSize: 6 });
 
   function handleStartWriting() {
     if (isAuthenticated) {

--- a/frontend/src/pages/PoemPage.tsx
+++ b/frontend/src/pages/PoemPage.tsx
@@ -6,8 +6,8 @@ import { PoemDetail } from '@/components/poem/PoemDetail';
 import { Link } from 'react-router-dom';
 
 export function PoemPage() {
-  var { poemId } = useParams<{ poemId: string }>();
-  var { data: poem, isLoading, isError } = usePoem(poemId ?? '');
+  const { poemId } = useParams<{ poemId: string }>();
+  const { data: poem, isLoading, isError } = usePoem(poemId ?? '');
 
   usePageMeta(
     poem ? `${poem.title} — Stanza Bonanza` : 'Stanza Bonanza',

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -19,15 +19,15 @@ import type { User } from '@/types/user';
 type Tab = 'poems' | 'followers' | 'following';
 
 function RegisterPasskeyButton() {
-  var [status, setStatus] = useState<'idle' | 'pending' | 'done' | 'error'>('idle');
-  var [errorMsg, setErrorMsg] = useState('');
+  const [status, setStatus] = useState<'idle' | 'pending' | 'done' | 'error'>('idle');
+  const [errorMsg, setErrorMsg] = useState('');
 
   async function handleRegister() {
     setStatus('pending');
     setErrorMsg('');
     try {
-      var options = await api.post<Parameters<typeof startRegistration>[0]>('/auth/register/begin');
-      var result = await startRegistration({ optionsJSON: options as any });
+      const optionsJSON = await api.post<Parameters<typeof startRegistration>[0]['optionsJSON']>('/auth/register/begin');
+      const result = await startRegistration({ optionsJSON });
       await api.post('/auth/register/finish', result);
       setStatus('done');
     } catch (err) {
@@ -55,12 +55,12 @@ function RegisterPasskeyButton() {
 }
 
 function EditProfileForm({ user, onDone }: { user: User; onDone: () => void }) {
-  var [displayName, setDisplayName] = useState(user.displayName);
-  var [bio, setBio] = useState(user.bio ?? '');
-  var [avatarUrl, setAvatarUrl] = useState(user.avatarUrl ?? '');
-  var [error, setError] = useState('');
-  var updateProfile = useUpdateProfile();
-  var { setUser } = useAuthStore();
+  const [displayName, setDisplayName] = useState(user.displayName);
+  const [bio, setBio] = useState(user.bio ?? '');
+  const [avatarUrl, setAvatarUrl] = useState(user.avatarUrl ?? '');
+  const [error, setError] = useState('');
+  const updateProfile = useUpdateProfile();
+  const { setUser } = useAuthStore();
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -144,16 +144,16 @@ function UserList({ users }: { users: User[] }) {
 }
 
 export function ProfilePage() {
-  var { userId } = useParams<{ userId: string }>();
-  var { user: me, isAuthenticated } = useAuthStore();
-  var [activeTab, setActiveTab] = useState<Tab>('poems');
-  var [editing, setEditing] = useState(false);
+  const { userId } = useParams<{ userId: string }>();
+  const { user: me, isAuthenticated } = useAuthStore();
+  const [activeTab, setActiveTab] = useState<Tab>('poems');
+  const [editing, setEditing] = useState(false);
 
-  var { data: profile, isLoading } = useUserProfile(userId ?? '');
-  var { data: poemsData } = useUserPoems(userId ?? '');
-  var { data: followersData } = useFollowers(userId ?? '', { pageSize: 50 });
-  var { data: followingData } = useFollowing(userId ?? '', { pageSize: 50 });
-  var toggleFollow = useToggleFollow(userId ?? '');
+  const { data: profile, isLoading } = useUserProfile(userId ?? '');
+  const { data: poemsData } = useUserPoems(userId ?? '');
+  const { data: followersData } = useFollowers(userId ?? '', { pageSize: 50 });
+  const { data: followingData } = useFollowing(userId ?? '', { pageSize: 50 });
+  const toggleFollow = useToggleFollow(userId ?? '');
 
   if (!userId) {
     return <Navigate to="/" replace />;
@@ -181,13 +181,13 @@ export function ProfilePage() {
     );
   }
 
-  var isOwnProfile = isAuthenticated && me?.id === userId;
-  var followerCount = followersData?.totalCount ?? 0;
-  var followingCount = followingData?.totalCount ?? 0;
-  var poemCount = poemsData?.totalCount ?? 0;
-  var amFollowing = followersData?.items.some((u) => u.id === me?.id) ?? false;
+  const isOwnProfile = isAuthenticated && me?.id === userId;
+  const followerCount = followersData?.totalCount ?? 0;
+  const followingCount = followingData?.totalCount ?? 0;
+  const poemCount = poemsData?.totalCount ?? 0;
+  const amFollowing = followersData?.items.some((u) => u.id === me?.id) ?? false;
 
-  var tabs: { id: Tab; label: string; count: number }[] = [
+  const tabs: { id: Tab; label: string; count: number }[] = [
     { id: 'poems', label: 'Poems', count: poemCount },
     { id: 'followers', label: 'Followers', count: followerCount },
     { id: 'following', label: 'Following', count: followingCount },

--- a/frontend/src/pages/TutorialDetailPage.tsx
+++ b/frontend/src/pages/TutorialDetailPage.tsx
@@ -6,16 +6,16 @@ import { PoemFormatBadge } from '@/components/poem/PoemFormatBadge';
 import { formatDate } from '@/lib/utils';
 
 export function TutorialDetailPage() {
-  var { slug } = useParams<{ slug: string }>();
-  var { data: tutorial, isLoading, isError } = useTutorial(slug ?? '');
+  const { slug } = useParams<{ slug: string }>();
+  const { data: tutorial, isLoading, isError } = useTutorial(slug ?? '');
 
   if (isLoading) {
     return (
       <div className="mx-auto max-w-2xl animate-pulse space-y-4 py-8">
         <div className="h-8 w-2/3 rounded bg-parchment-dark" />
         <div className="space-y-3">
-          {Array.from({ length: 8 }).map((_, i) => (
-            <div key={i} className="h-4 rounded bg-parchment-dark" style={{ width: `${70 + Math.random() * 30}%` }} />
+          {[92, 78, 85, 70, 96, 74, 88, 82].map((w, i) => (
+            <div key={i} className="h-4 rounded bg-parchment-dark" style={{ width: `${w}%` }} />
           ))}
         </div>
       </div>

--- a/frontend/src/pages/TutorialsPage.tsx
+++ b/frontend/src/pages/TutorialsPage.tsx
@@ -4,14 +4,14 @@ import { useTutorials } from '@/hooks/useTutorials';
 import { PoemFormatBadge } from '@/components/poem/PoemFormatBadge';
 import type { Difficulty } from '@/types/tutorial';
 
-var difficultyColors: Record<Difficulty, string> = {
+const difficultyColors: Record<Difficulty, string> = {
   beginner: 'bg-green-100 text-green-700',
   intermediate: 'bg-yellow-100 text-yellow-700',
   advanced: 'bg-red-100 text-red-700',
 };
 
 export function TutorialsPage() {
-  var { data: tutorials, isLoading } = useTutorials();
+  const { data: tutorials, isLoading } = useTutorials();
 
   return (
     <div>

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -13,7 +13,7 @@ import { TutorialDetailPage } from '@/pages/TutorialDetailPage';
 import { MagicLinkVerify } from '@/components/auth/MagicLinkVerify';
 import { NotFoundPage } from '@/pages/NotFoundPage';
 
-export var router = createBrowserRouter([
+export const router = createBrowserRouter([
   {
     element: <AppShell />,
     children: [

--- a/frontend/src/stores/authStore.test.ts
+++ b/frontend/src/stores/authStore.test.ts
@@ -12,7 +12,7 @@ vi.mock('@/lib/api', () => ({
 
 import { api } from '@/lib/api';
 
-var mockUser: User = {
+const mockUser: User = {
   id: 'user-1',
   displayName: 'Ada Lovelace',
   email: 'ada@example.com',
@@ -35,7 +35,7 @@ describe('fetchUser', () => {
 
     await useAuthStore.getState().fetchUser();
 
-    var state = useAuthStore.getState();
+    const state = useAuthStore.getState();
     expect(state.user).toEqual(mockUser);
     expect(state.isAuthenticated).toBe(true);
     expect(state.isLoading).toBe(false);
@@ -46,7 +46,7 @@ describe('fetchUser', () => {
 
     await useAuthStore.getState().fetchUser();
 
-    var state = useAuthStore.getState();
+    const state = useAuthStore.getState();
     expect(state.user).toBeNull();
     expect(state.isAuthenticated).toBe(false);
     expect(state.isLoading).toBe(false);
@@ -68,7 +68,7 @@ describe('logout', () => {
 
     await useAuthStore.getState().logout();
 
-    var state = useAuthStore.getState();
+    const state = useAuthStore.getState();
     expect(state.user).toBeNull();
     expect(state.isAuthenticated).toBe(false);
   });
@@ -88,7 +88,7 @@ describe('logout', () => {
     // The promise rejects but the finally block still clears state.
     await useAuthStore.getState().logout().catch(() => undefined);
 
-    var state = useAuthStore.getState();
+    const state = useAuthStore.getState();
     expect(state.user).toBeNull();
     expect(state.isAuthenticated).toBe(false);
   });
@@ -98,7 +98,7 @@ describe('setUser', () => {
   it('sets user and marks isAuthenticated true when given a user', () => {
     useAuthStore.getState().setUser(mockUser);
 
-    var state = useAuthStore.getState();
+    const state = useAuthStore.getState();
     expect(state.user).toEqual(mockUser);
     expect(state.isAuthenticated).toBe(true);
   });
@@ -107,7 +107,7 @@ describe('setUser', () => {
     useAuthStore.setState({ user: mockUser, isAuthenticated: true, isLoading: false });
     useAuthStore.getState().setUser(null);
 
-    var state = useAuthStore.getState();
+    const state = useAuthStore.getState();
     expect(state.user).toBeNull();
     expect(state.isAuthenticated).toBe(false);
   });

--- a/frontend/src/stores/authStore.ts
+++ b/frontend/src/stores/authStore.ts
@@ -18,7 +18,7 @@ export const useAuthStore = create<AuthState>((set) => ({
 
   fetchUser: async () => {
     try {
-      var user = await api.get<User>('/auth/me');
+      const user = await api.get<User>('/auth/me');
       set({ user, isAuthenticated: true, isLoading: false });
     } catch {
       set({ user: null, isAuthenticated: false, isLoading: false });

--- a/frontend/src/test/helpers.tsx
+++ b/frontend/src/test/helpers.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-refresh/only-export-components -- test-only helpers, fast refresh N/A */
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouter } from 'react-router-dom';
 import type { ReactNode } from 'react';
@@ -12,7 +13,7 @@ export function makeQueryClient() {
 }
 
 export function Wrapper({ children }: { children: ReactNode }) {
-  var client = makeQueryClient();
+  const client = makeQueryClient();
   return (
     <MemoryRouter>
       <QueryClientProvider client={client}>{children}</QueryClientProvider>


### PR DESCRIPTION
Closes #61 (the deferred lint half). Verified locally: `eslint .` clean (0 problems), build + 55 tests green.

- `eslint --fix` across the tree (mostly `var`→`const`).
- Manual fixes for what `--fix` could not: typed the WebAuthn `optionsJSON` instead of `as any` (login + register), deterministic skeleton widths instead of `Math.random` in render, resync the like buttons via during-render state instead of an effect (removes the `set-state-in-effect` violations), and the magic-link no-token case handled at render.
- Two justified, commented `eslint-disable`s: the notifications "mark read on open" effect deps, and the test-only helpers file.
- Added `pnpm lint` to the frontend CI job (removed the "deferred" comment), so lint now gates every PR.

Closes #61.