### PR TITLE
Run DB migrations on deploy (Fly release_command)

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -4,10 +4,13 @@ COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 go build -o server ./cmd/server
+# migrate CLI for the release_command (runs migrations on deploy)
+RUN go install -tags 'postgres' github.com/golang-migrate/migrate/v4/cmd/migrate@v4.18.1
 
 FROM alpine:3.20
 RUN apk add --no-cache ca-certificates tzdata
 COPY --from=builder /app/server /server
+COPY --from=builder /go/bin/migrate /usr/local/bin/migrate
 COPY --from=builder /app/migrations /migrations
 EXPOSE 8080
 CMD ["/server"]

--- a/backend/fly.toml
+++ b/backend/fly.toml
@@ -9,6 +9,9 @@ primary_region = 'lhr'
 [build]
   dockerfile = 'Dockerfile'
 
+[deploy]
+  release_command = "sh -c '/usr/local/bin/migrate -path /migrations -database \"$DATABASE_URL\" up'"
+
 [env]
   PORT = '8080'
 


### PR DESCRIPTION
Makes `fly deploy` migrate then deploy atomically, so the backend redeploy is a single safe command.

- Dockerfile bundles the `migrate` CLI (built with the postgres tag).
- `fly.toml` gets a `[deploy] release_command` that runs `migrate ... up` against the app's `DATABASE_URL` secret before the new machines go live. If it fails, Fly aborts the deploy (no half-migrated state).

Verified locally with `docker build`: image builds, `migrate` runs, all 8 migration files are in `/migrations`. The Fly-side run can only be confirmed on an actual deploy (I have no Fly access here).

**Why it matters now:** this session added `000002_tags`, `000003_stanza_likes`, `000004_poem_drafts`. The current backend code references `p.published`, `s.like_count` and the new tables, so deploying without these migrations breaks poem queries.